### PR TITLE
Include error type in Gemini arbiter errors

### DIFF
--- a/moe/arbiter.ts
+++ b/moe/arbiter.ts
@@ -157,7 +157,7 @@ export const arbitrateStream = async (
             throw new Error(`Gemini API Error: ${error.message}`, { cause: error });
         } else if (error instanceof Error) {
             throw new Error(
-                `An error occurred with the Gemini Arbiter: ${error.message}`,
+                `An error occurred with the Gemini Arbiter (${error.name}): ${error.message}`,
                 { cause: error }
             );
         } else {


### PR DESCRIPTION
## Summary
- add error name to Gemini Arbiter error messages for clearer debugging

## Testing
- `npx -y vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68ab9017d5788322a07d2547b26d4bf3