### PR TITLE
fix: resolve remaining merge conflicts

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="40" fill="#4b5563"/>
-  <text x="50" y="55" font-size="45" text-anchor="middle" fill="#fff">H</text>
+  <circle cx="50" cy="50" r="50" fill="#14532d"/>
+  <text x="50" y="60" font-size="60" text-anchor="middle" fill="#ecfccb" font-family="sans-serif">O</text>
 </svg>

--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -86,7 +86,7 @@ const runExpertGeminiDeepConf = async (
     
     const createProvider = (): TraceProvider => {
         return {
-            generate: async (p, abortSignal) => {
+            generate: async (p, abortSignal) => { // p is the prompt string
                 const text = await runExpertGeminiSingle(expert, p, images, config, abortSignal);
                 // Gemini API doesn't give us steps/tokens, so we create a mock Trace
                 const trace: Trace = {
@@ -164,7 +164,7 @@ const runExpertOpenAIDeepConf = async (
     
     const createProvider = (): TraceProvider => {
         return {
-            generate: async (p, abortSignal) => {
+            generate: async (p, abortSignal) => { // p is the prompt string
                 // Since logprobs are not available, we generate the full text and mock the trace.
                 const text = await runExpertOpenAISingle(expert, p, images, config, abortSignal);
                 // Mock Trace for judge-based DeepConf

--- a/services/deepconf.ts
+++ b/services/deepconf.ts
@@ -155,7 +155,7 @@ export const judgeAnswer = async (prompt: string, answer: string, agentModel: st
 
         if (isJudgePayload(parsed)) {
             return {
-                score: Math.max(0, Math.min(1, parsed.score)),
+                score: Math.max(0, Math.min(1, parsed.score)), // Clamp score between 0 and 1
                 reasons: parsed.reasons
             };
         }


### PR DESCRIPTION
## Summary
- switch favicon to green "O" variant
- document prompt argument in DeepConf generator wrappers
- clarify score clamping logic in DeepConf judge handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abe59cd1508322a87704acbaf91aa4