### PR TITLE
refactor: unify app URL and Gemini response helpers

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,16 +1,15 @@
-export const getAppUrl = (): string => {
-  if (typeof window !== 'undefined' && window.location) {
-    return window.location.origin;
-  }
-  return 'http://localhost';
-};
+export const getAppUrl = (): string =>
+  typeof window !== 'undefined' && window.location
+    ? window.location.origin
+    : import.meta.env.VITE_APP_URL ?? 'http://localhost';
 
-export const getGeminiResponseText = (data: any): string => {
-  try {
-    const parts = data?.candidates?.[0]?.content?.parts;
-    if (!parts) return '';
-    return parts.map((p: any) => (typeof p.text === 'string' ? p.text : '')).join('');
-  } catch {
-    return '';
-  }
+export const getGeminiResponseText = (response: unknown): string => {
+  if (!response) return '';
+  // The Gemini SDK has evolved over time; depending on the version or
+  // API surface, the response may expose its text either as a property or
+  // a method. We reflectively access it and support both shapes.
+  const textProp = Reflect.get(response as object, 'text') as unknown;
+  return typeof textProp === 'function'
+    ? textProp.call(response) ?? ''
+    : (textProp as string | undefined) ?? '';
 };


### PR DESCRIPTION
## Summary
- resolve app URL based on browser origin, env var, or localhost fallback
- handle Gemini responses that expose text as a method or property

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68abe8a0875883229575ed5f36a4cf5d