### PR TITLE
Handle Gemini rate limits with retries

### DIFF
--- a/moe/arbiter.ts
+++ b/moe/arbiter.ts
@@ -10,6 +10,7 @@ import {
     OPENAI_ARBITER_MODEL,
 } from '@/constants';
 import { GeminiThinkingEffort } from '@/types';
+import { callWithGeminiRetry, isGeminiRateLimitError, GEMINI_QUOTA_MESSAGE } from '@/services/geminiUtils';
 
 const GEMINI_PRO_BUDGETS: Record<Extract<GeminiThinkingEffort, 'low' | 'medium' | 'high' | 'dynamic'>, number> = {
     low: 8192,
@@ -147,19 +148,32 @@ export const arbitrateStream = async (
     const budget = GEMINI_PRO_BUDGETS[effortForPro];
 
     const geminiAI = getGeminiClient();
-    const stream = await geminiAI.models.generateContentStream({
-        model: GEMINI_PRO_MODEL, // Arbiter always uses the Pro model for Gemini
-        contents: { parts: [{ text: arbiterPrompt }] },
-        config: {
-            systemInstruction: ARBITER_PERSONA,
-            thinkingConfig: { thinkingBudget: budget },
-        }
-    });
+    try {
+        const stream = await callWithGeminiRetry(() =>
+            geminiAI.models.generateContentStream({
+                model: GEMINI_PRO_MODEL, // Arbiter always uses the Pro model for Gemini
+                contents: { parts: [{ text: arbiterPrompt }] },
+                config: {
+                    systemInstruction: ARBITER_PERSONA,
+                    thinkingConfig: { thinkingBudget: budget },
+                }
+            })
+        );
 
-    async function* transformGeminiStream(): AsyncGenerator<{ text: string }> {
-        for await (const chunk of stream) {
-            yield { text: getGeminiResponseText(chunk) };
+        async function* transformGeminiStream(): AsyncGenerator<{ text: string }> {
+            for await (const chunk of stream) {
+                yield { text: getGeminiResponseText(chunk) };
+            }
         }
+        return transformGeminiStream();
+    } catch (error) {
+        console.error("Error calling the Gemini API for arbiter:", error);
+        if (isGeminiRateLimitError(error)) {
+            throw new Error(GEMINI_QUOTA_MESSAGE);
+        }
+        if (error instanceof Error) {
+            throw new Error(`An error occurred with the Gemini Arbiter: ${error.message}`);
+        }
+        throw new Error(`An unknown error occurred while communicating with the Gemini model for arbitration.`);
     }
-    return transformGeminiStream();
 };

--- a/moe/arbiter.ts
+++ b/moe/arbiter.ts
@@ -10,7 +10,7 @@ import {
     OPENAI_ARBITER_MODEL,
 } from '@/constants';
 import { GeminiThinkingEffort } from '@/types';
-import { callWithGeminiRetry, isGeminiRateLimitError, GEMINI_QUOTA_MESSAGE } from '@/services/geminiUtils';
+import { callWithGeminiRetry, handleGeminiError } from '@/services/geminiUtils';
 
 const GEMINI_PRO_BUDGETS: Record<Extract<GeminiThinkingEffort, 'low' | 'medium' | 'high' | 'dynamic'>, number> = {
     low: 8192,
@@ -167,13 +167,6 @@ export const arbitrateStream = async (
         }
         return transformGeminiStream();
     } catch (error) {
-        console.error("Error calling the Gemini API for arbiter:", error);
-        if (isGeminiRateLimitError(error)) {
-            throw new Error(GEMINI_QUOTA_MESSAGE);
-        }
-        if (error instanceof Error) {
-            throw new Error(`An error occurred with the Gemini Arbiter: ${error.message}`);
-        }
-        throw new Error(`An unknown error occurred while communicating with the Gemini model for arbitration.`);
+        handleGeminiError(error, 'arbiter', 'arbitration');
     }
 };

--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -3,7 +3,7 @@ import { GenerateContentParameters, Part } from "@google/genai";
 import { Draft, ExpertDispatch } from './types';
 import { getGeminiClient, getOpenAIClient, getOpenRouterApiKey } from '@/services/llmService';
 import { getAppUrl, getGeminiResponseText } from '@/lib/utils';
-import { callWithGeminiRetry, isGeminiRateLimitError, GEMINI_QUOTA_MESSAGE } from '@/services/geminiUtils';
+import { callWithGeminiRetry, handleGeminiError } from '@/services/geminiUtils';
 import { GEMINI_PRO_MODEL, GEMINI_FLASH_MODEL, OPENAI_REASONING_PROMPT_PREFIX } from '@/constants';
 import { AgentConfig, GeminiAgentConfig, ImageState, OpenAIAgentConfig, GeminiThinkingEffort, OpenRouterAgentConfig } from '@/types';
 import {
@@ -77,14 +77,7 @@ const runExpertGeminiSingle = async (
         const response = await callWithGeminiRetry(() => geminiAI.models.generateContent(generateContentParams));
         return getGeminiResponseText(response);
     } catch (error) {
-        console.error("Error calling the Gemini API for dispatcher:", error);
-        if (isGeminiRateLimitError(error)) {
-            throw new Error(GEMINI_QUOTA_MESSAGE);
-        }
-        if (error instanceof Error) {
-            throw new Error(`An error occurred with the Gemini Dispatcher: ${error.message}`);
-        }
-        throw new Error(`An unknown error occurred while communicating with the Gemini model for dispatch.`);
+        handleGeminiError(error, 'dispatcher', 'dispatch');
     }
 }
 

--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -77,10 +77,14 @@ const runExpertGeminiSingle = async (
         const response = await callWithGeminiRetry(() => geminiAI.models.generateContent(generateContentParams));
         return getGeminiResponseText(response);
     } catch (error) {
+        console.error("Error calling the Gemini API for dispatcher:", error);
         if (isGeminiRateLimitError(error)) {
             throw new Error(GEMINI_QUOTA_MESSAGE);
         }
-        throw error;
+        if (error instanceof Error) {
+            throw new Error(`An error occurred with the Gemini Dispatcher: ${error.message}`);
+        }
+        throw new Error(`An unknown error occurred while communicating with the Gemini model for dispatch.`);
     }
 }
 

--- a/services/geminiUtils.ts
+++ b/services/geminiUtils.ts
@@ -24,5 +24,17 @@ export const callWithGeminiRetry = async <T>(
             await sleep(baseDelayMs * Math.pow(2, attempt));
         }
     }
-    throw new Error('callWithGeminiRetry failed unexpectedly');
+};
+
+const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+export const handleGeminiError = (error: unknown, context: string, action?: string): never => {
+    console.error(`Error calling the Gemini API for ${context}:`, error);
+    if (isGeminiRateLimitError(error)) {
+        throw new Error(GEMINI_QUOTA_MESSAGE);
+    }
+    if (error instanceof Error) {
+        throw new Error(`An error occurred with the Gemini ${capitalize(context)}: ${error.message}`);
+    }
+    throw new Error(`An unknown error occurred while communicating with the Gemini model for ${action ?? context}.`);
 };

--- a/services/geminiUtils.ts
+++ b/services/geminiUtils.ts
@@ -24,4 +24,5 @@ export const callWithGeminiRetry = async <T>(
             await sleep(baseDelayMs * Math.pow(2, attempt));
         }
     }
+    throw new Error('callWithGeminiRetry failed unexpectedly');
 };

--- a/services/geminiUtils.ts
+++ b/services/geminiUtils.ts
@@ -24,6 +24,7 @@ export const callWithGeminiRetry = async <T>(
             await sleep(baseDelayMs * Math.pow(2, attempt));
         }
     }
+    throw new Error("Failed to complete Gemini request after retries.");
 };
 
 const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);

--- a/services/geminiUtils.ts
+++ b/services/geminiUtils.ts
@@ -14,15 +14,14 @@ export const callWithGeminiRetry = async <T>(
     retries = 2,
     baseDelayMs = 1000,
 ): Promise<T> => {
-    for (let attempt = 0; attempt < retries; attempt++) {
+    for (let attempt = 0; attempt <= retries; attempt++) {
         try {
             return await fn();
         } catch (error) {
-            if (!isGeminiRateLimitError(error)) {
+            if (!isGeminiRateLimitError(error) || attempt === retries) {
                 throw error;
             }
             await sleep(baseDelayMs * Math.pow(2, attempt));
         }
     }
-    return fn();
 };

--- a/services/geminiUtils.ts
+++ b/services/geminiUtils.ts
@@ -3,8 +3,12 @@ export const GEMINI_QUOTA_MESSAGE = "Gemini quota exceeded, please wait before r
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export const isGeminiRateLimitError = (error: unknown): boolean => {
-    const status = (error as any)?.status || (error as any)?.response?.status;
-    const rawMessage = (error as any)?.message;
+    if (typeof error !== 'object' || error === null) {
+        return false;
+    }
+    const maybeError = error as { status?: number; response?: { status?: number }; message?: unknown };
+    const status = maybeError.status ?? maybeError.response?.status;
+    const rawMessage = maybeError.message;
     const message = typeof rawMessage === 'string' ? rawMessage.toLowerCase() : '';
     return status === 429 || message.includes('rate limit') || message.includes('quota');
 };

--- a/services/geminiUtils.ts
+++ b/services/geminiUtils.ts
@@ -4,22 +4,25 @@ const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export const isGeminiRateLimitError = (error: unknown): boolean => {
     const status = (error as any)?.status || (error as any)?.response?.status;
-    const message: string = (error as any)?.message?.toLowerCase?.() || '';
+    const rawMessage = (error as any)?.message;
+    const message = typeof rawMessage === 'string' ? rawMessage.toLowerCase() : '';
     return status === 429 || message.includes('rate limit') || message.includes('quota');
 };
 
-export const callWithGeminiRetry = async <T>(fn: () => Promise<T>, retries = 2, baseDelayMs = 1000): Promise<T> => {
-    for (let attempt = 0; attempt <= retries; attempt++) {
+export const callWithGeminiRetry = async <T>(
+    fn: () => Promise<T>,
+    retries = 2,
+    baseDelayMs = 1000,
+): Promise<T> => {
+    for (let attempt = 0; attempt < retries; attempt++) {
         try {
             return await fn();
         } catch (error) {
-            if (isGeminiRateLimitError(error) && attempt < retries) {
-                await sleep(baseDelayMs * Math.pow(2, attempt));
-                continue;
+            if (!isGeminiRateLimitError(error)) {
+                throw error;
             }
-            throw error;
+            await sleep(baseDelayMs * Math.pow(2, attempt));
         }
     }
-    // Should not reach here
-    throw new Error('Failed to execute Gemini request');
+    return fn();
 };

--- a/services/geminiUtils.ts
+++ b/services/geminiUtils.ts
@@ -1,0 +1,25 @@
+export const GEMINI_QUOTA_MESSAGE = "Gemini quota exceeded, please wait before retrying.";
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export const isGeminiRateLimitError = (error: unknown): boolean => {
+    const status = (error as any)?.status || (error as any)?.response?.status;
+    const message: string = (error as any)?.message?.toLowerCase?.() || '';
+    return status === 429 || message.includes('rate limit') || message.includes('quota');
+};
+
+export const callWithGeminiRetry = async <T>(fn: () => Promise<T>, retries = 2, baseDelayMs = 1000): Promise<T> => {
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+            return await fn();
+        } catch (error) {
+            if (isGeminiRateLimitError(error) && attempt < retries) {
+                await sleep(baseDelayMs * Math.pow(2, attempt));
+                continue;
+            }
+            throw error;
+        }
+    }
+    // Should not reach here
+    throw new Error('Failed to execute Gemini request');
+};

--- a/services/geminiUtils.ts
+++ b/services/geminiUtils.ts
@@ -14,17 +14,16 @@ export const callWithGeminiRetry = async <T>(
     retries = 2,
     baseDelayMs = 1000,
 ): Promise<T> => {
-    for (let attempt = 0; attempt <= retries; attempt++) {
+    for (let attempt = 0; ; attempt++) {
         try {
             return await fn();
         } catch (error) {
-            if (!isGeminiRateLimitError(error) || attempt === retries) {
+            if (!isGeminiRateLimitError(error) || attempt >= retries) {
                 throw error;
             }
             await sleep(baseDelayMs * Math.pow(2, attempt));
         }
     }
-    throw new Error("Failed to complete Gemini request after retries.");
 };
 
 const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);


### PR DESCRIPTION
## Summary
- add shared Gemini retry utility to detect rate limits
- surface quota errors for Gemini judge and agent calls
- retry Gemini arbiter and dispatcher calls with backoff

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac07b7e7a08322a7fe1596e0c6f67b