### PR TITLE
feat: add gpt5 mini and shortcuts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -777,7 +777,7 @@ const App: React.FC = () => {
                         <header className="text-center py-8 relative">
                             <img src={`${import.meta.env.BASE_URL}assets/banner.svg`} alt="HeavyOrc banner" className="mx-auto mb-4 w-full max-w-2xl" />
                             <h1 className="text-4xl sm:text-5xl font-bold text-[var(--text)] flex items-center justify-center gap-3">
-                                <ShieldCheckIcon className="w-10 h-10 text-emerald-400" />
+                                <ShieldCheckIcon className="w-10 h-10 text-emerald-400" aria-hidden="true" />
                                 HeavyOrc
                             </h1>
                             <div className="absolute top-8 right-0 flex items-center gap-2">
@@ -787,7 +787,7 @@ const App: React.FC = () => {
                                     className="flex items-center gap-2 px-3 py-1.5 text-sm bg-[var(--surface-1)] text-[var(--text)] font-semibold rounded-lg shadow-md hover:bg-[var(--surface-active)] disabled:bg-[var(--surface-2)] disabled:text-[var(--text-muted)] disabled:cursor-not-allowed transition-colors"
                                     title="Save final answer and all drafts to a ZIP file"
                                 >
-                                    <DownloadIcon className="w-4 h-4" />
+                                    <DownloadIcon className="w-4 h-4" aria-hidden="true" />
                                     Save
                                 </button>
                                 <button
@@ -796,7 +796,7 @@ const App: React.FC = () => {
                                     title="Settings"
                                     aria-label="Open Settings"
                                 >
-                                    <CogIcon className="w-6 h-6" />
+                                    <CogIcon className="w-6 h-6" aria-hidden="true" />
                                 </button>
                             </div>
                             <p className="mt-4 text-lg text-[var(--text-muted)] max-w-3xl mx-auto">
@@ -830,7 +830,7 @@ const App: React.FC = () => {
                                             variants={itemVariants}
                                         >
                                             <div className="flex items-start">
-                                                <ExclamationTriangleIcon className="w-5 h-5 mr-3 mt-0.5 text-[var(--warn)] flex-shrink-0" />
+                                                <ExclamationTriangleIcon className="w-5 h-5 mr-3 mt-0.5 text-[var(--warn)] flex-shrink-0" aria-hidden="true" />
                                                 <div>
                                                     <strong className="font-bold">Automatic Model Switch:</strong>
                                                     <span className="block sm:inline sm:ml-2">{displayData.arbiterSwitchWarning}</span>

--- a/App.tsx
+++ b/App.tsx
@@ -81,7 +81,7 @@ const Toast: React.FC<{ message: string; type: 'success' | 'error'; onClose: () 
 
     return (
         <div
-            className={`fixed bottom-5 right-5 p-4 rounded-lg shadow-2xl bg-opacity-20 border z-50 animate-fade-in-up flex items-center gap-4 ${colorClasses}`}
+            className={`fixed bottom-5 right-5 p-4 rounded-lg shadow-2xl border z-50 animate-fade-in-up flex items-center gap-4 ${colorClasses}`}
             style={{ animationDuration: '0.3s' }}
         >
             <span>{message}</span>
@@ -474,7 +474,7 @@ const App: React.FC = () => {
 
     useEffect(() => {
         const handler = (e: KeyboardEvent) => {
-            if (e.isComposing) return;
+            if (e.isComposing || e.repeat) return;
             const target = e.target as HTMLElement;
             const tag = target.tagName;
             const isTyping = tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable;

--- a/App.tsx
+++ b/App.tsx
@@ -464,7 +464,6 @@ const App: React.FC = () => {
     }, []);
 
     const latestHandleRun = useRef(handleRun);
-    const agentsRef = useRef(agents);
     const isHistoryViewRef = useRef(false);
 
     useEffect(() => {

--- a/App.tsx
+++ b/App.tsx
@@ -478,6 +478,7 @@ const App: React.FC = () => {
 
     useEffect(() => {
         const handler = (e: KeyboardEvent) => {
+            if (e.isComposing) return;
             const target = e.target as HTMLElement;
             const tag = target.tagName;
             const isTyping = tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable;

--- a/App.tsx
+++ b/App.tsx
@@ -76,8 +76,8 @@ const Toast: React.FC<{ message: string; type: 'success' | 'error'; onClose: () 
 
     const colorClasses =
         type === 'success'
-            ? 'bg-[var(--success)] border-[var(--success)] text-[var(--success)]'
-            : 'bg-[var(--danger)] border-[var(--danger)] text-[var(--danger)]';
+            ? 'bg-[var(--success)] border-[var(--success)] text-[var(--text)]'
+            : 'bg-[var(--danger)] border-[var(--danger)] text-[var(--text)]';
 
     return (
         <div

--- a/App.tsx
+++ b/App.tsx
@@ -74,17 +74,19 @@ const Toast: React.FC<{ message: string; type: 'success' | 'error'; onClose: () 
         return () => clearTimeout(timer);
     }, [onClose]);
 
-    const bgColor = type === 'success' ? 'bg-green-800/90' : 'bg-red-800/90';
-    const borderColor = type === 'success' ? 'border-green-600' : 'border-red-600';
+    const colorClasses =
+        type === 'success'
+            ? 'bg-[var(--success)] border-[var(--success)] text-[var(--success)]'
+            : 'bg-[var(--danger)] border-[var(--danger)] text-[var(--danger)]';
 
     return (
-        <div 
-            className={`fixed bottom-5 right-5 p-4 rounded-lg shadow-2xl text-white border ${borderColor} ${bgColor} z-50 animate-fade-in-up flex items-center gap-4`}
+        <div
+            className={`fixed bottom-5 right-5 p-4 rounded-lg shadow-2xl bg-opacity-20 border z-50 animate-fade-in-up flex items-center gap-4 ${colorClasses}`}
             style={{ animationDuration: '0.3s' }}
         >
             <span>{message}</span>
-            <button onClick={onClose} className="p-1 rounded-full hover:bg-black/20" aria-label="Close notification">
-                <XMarkIcon className="w-5 h-5" />
+            <button onClick={onClose} className="p-1 rounded-full hover:bg-[var(--surface-active)]" aria-label="Close notification">
+                <XMarkIcon className="w-5 h-5" aria-hidden="true" />
             </button>
         </div>
     );

--- a/App.tsx
+++ b/App.tsx
@@ -463,6 +463,7 @@ const App: React.FC = () => {
 
     const latestHandleRun = useRef(handleRun);
     const agentsRef = useRef(agents);
+    const isHistoryViewRef = useRef(false);
 
     useEffect(() => {
         latestHandleRun.current = handleRun;
@@ -471,6 +472,7 @@ const App: React.FC = () => {
     useEffect(() => {
         agentsRef.current = agents;
     }, [agents]);
+
 
     useEffect(() => {
         const handler = (e: KeyboardEvent) => {
@@ -481,13 +483,13 @@ const App: React.FC = () => {
             if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'enter') {
                 e.preventDefault();
                 latestHandleRun.current();
-            } else if (!isTyping && !(e.metaKey || e.ctrlKey || e.altKey) && e.key.toLowerCase() === 'a') {
+            } else if (!isTyping && !isHistoryViewRef.current && !(e.metaKey || e.ctrlKey || e.altKey) && e.key.toLowerCase() === 'a') {
                 e.preventDefault();
                 openAddExpertRef.current?.();
-            } else if (!isTyping && !(e.metaKey || e.ctrlKey || e.altKey) && e.key === '/') {
+            } else if (!isTyping && !isHistoryViewRef.current && !(e.metaKey || e.ctrlKey || e.altKey) && e.key === '/') {
                 e.preventDefault();
                 promptInputRef.current?.focus();
-            } else if (!isTyping && !(e.metaKey || e.ctrlKey || e.altKey) && e.key >= '1' && e.key <= '9') {
+            } else if (!isTyping && !isHistoryViewRef.current && !(e.metaKey || e.ctrlKey || e.altKey) && e.key >= '1' && e.key <= '9') {
                 const index = parseInt(e.key, 10) - 1;
                 const agent = agentsRef.current[index];
                 if (!agent) return;
@@ -563,6 +565,10 @@ const App: React.FC = () => {
         };
     }, [selectedRun, prompt, images, agentConfigs, arbiterModel, openAIArbiterVerbosity, geminiArbiterEffort, finalAnswer, agents, arbiterSwitchWarning]);
 
+
+    useEffect(() => {
+        isHistoryViewRef.current = displayData.isHistoryView;
+    }, [displayData.isHistoryView]);
 
     const handleSaveAll = async () => {
         const dataToSave = displayData;

--- a/App.tsx
+++ b/App.tsx
@@ -471,10 +471,6 @@ const App: React.FC = () => {
         latestHandleRun.current = handleRun;
     }, [handleRun]);
 
-    useEffect(() => {
-        agentsRef.current = agents;
-    }, [agents]);
-
 
     useEffect(() => {
         const handler = (e: KeyboardEvent) => {
@@ -585,7 +581,8 @@ const App: React.FC = () => {
 
     useEffect(() => {
         isHistoryViewRef.current = displayData.isHistoryView;
-    }, [displayData.isHistoryView]);
+        agentsRef.current = displayData.agents;
+    }, [displayData]);
 
     const handleSaveAll = async () => {
         const dataToSave = displayData;

--- a/components/AddExpertModal.tsx
+++ b/components/AddExpertModal.tsx
@@ -37,15 +37,15 @@ const AddExpertModal: React.FC<AddExpertModalProps> = ({ isOpen, onClose, onAddE
             aria-modal="true"
             aria-labelledby="add-expert-title"
         >
-            <div 
-                className="bg-gray-800 rounded-xl shadow-2xl border border-gray-700 w-full max-w-2xl h-full max-h-[80vh] flex flex-col"
+            <div
+                className="bg-[var(--surface-2)] rounded-xl shadow-2xl border border-[var(--line)] w-full max-w-2xl h-full max-h-[80vh] flex flex-col"
                 onClick={e => e.stopPropagation()}
             >
-                <header className="flex items-center justify-between p-4 border-b border-gray-700 flex-shrink-0">
-                    <h2 id="add-expert-title" className="text-lg font-bold text-gray-100">
+                <header className="flex items-center justify-between p-4 border-b border-[var(--line)] flex-shrink-0">
+                    <h2 id="add-expert-title" className="text-lg font-bold text-[var(--text)]">
                         Add an Expert to the Ensemble
                     </h2>
-                     <button onClick={onClose} type="button" className="p-1 rounded-full text-gray-400 hover:bg-gray-700 hover:text-white" aria-label="Close modal">
+                     <button onClick={onClose} type="button" className="p-1 rounded-full text-[var(--text-muted)] hover:bg-[var(--surface-active)] hover:text-[var(--text)]" aria-label="Close modal">
                         <XMarkIcon className="w-6 h-6" />
                     </button>
                 </header>
@@ -56,13 +56,13 @@ const AddExpertModal: React.FC<AddExpertModalProps> = ({ isOpen, onClose, onAddE
                             <button
                                 key={expert.id}
                                 onClick={() => handleAdd(expert)}
-                                className="w-full h-full text-left p-4 bg-gray-900/50 rounded-lg border border-gray-700 hover:bg-indigo-900/40 hover:border-indigo-600 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 flex flex-col"
+                                className="w-full h-full text-left p-4 bg-[var(--surface-2)] rounded-lg border border-[var(--line)] hover:bg-[var(--surface-active)] hover:border-[var(--accent)] transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--accent)] flex flex-col"
                             >
                                 <div className="flex items-center gap-2 mb-2">
-                                    <SparklesIcon className="w-5 h-5 text-purple-400 flex-shrink-0" />
-                                    <h3 className="font-bold text-gray-200">{expert.name}</h3>
+                                    <SparklesIcon className="w-5 h-5 text-[var(--accent)] flex-shrink-0" />
+                                    <h3 className="font-bold text-[var(--text)]">{expert.name}</h3>
                                 </div>
-                                <p className="text-sm text-gray-400 flex-grow">
+                                <p className="text-sm text-[var(--text-muted)] flex-grow">
                                     {expert.persona}
                                 </p>
                             </button>

--- a/components/AddExpertModal.tsx
+++ b/components/AddExpertModal.tsx
@@ -45,8 +45,8 @@ const AddExpertModal: React.FC<AddExpertModalProps> = ({ isOpen, onClose, onAddE
                     <h2 id="add-expert-title" className="text-lg font-bold text-[var(--text)]">
                         Add an Expert to the Ensemble
                     </h2>
-                     <button onClick={onClose} type="button" className="p-1 rounded-full text-[var(--text-muted)] hover:bg-[var(--surface-active)] hover:text-[var(--text)]" aria-label="Close modal">
-                        <XMarkIcon className="w-6 h-6" />
+                    <button onClick={onClose} type="button" className="p-1 rounded-full text-[var(--text-muted)] hover:bg-[var(--surface-active)] hover:text-[var(--text)]" aria-label="Close modal">
+                        <XMarkIcon className="w-6 h-6" aria-hidden="true" />
                     </button>
                 </header>
                 
@@ -59,7 +59,7 @@ const AddExpertModal: React.FC<AddExpertModalProps> = ({ isOpen, onClose, onAddE
                                 className="w-full h-full text-left p-4 bg-[var(--surface-2)] rounded-lg border border-[var(--line)] hover:bg-[var(--surface-active)] hover:border-[var(--accent)] transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--accent)] flex flex-col"
                             >
                                 <div className="flex items-center gap-2 mb-2">
-                                    <SparklesIcon className="w-5 h-5 text-[var(--accent)] flex-shrink-0" />
+                                    <SparklesIcon className="w-5 h-5 text-[var(--accent)] flex-shrink-0" aria-hidden="true" />
                                     <h3 className="font-bold text-[var(--text)]">{expert.name}</h3>
                                 </div>
                                 <p className="text-sm text-[var(--text-muted)] flex-grow">

--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -1,5 +1,6 @@
 import React, { useId } from 'react';
 import { AgentState, AgentStatus } from '@/types';
+import { getExpertColor } from '@/lib/colors';
 import {
     LoadingSpinner,
     CheckCircleIcon,
@@ -65,12 +66,13 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, displayId, isCollapsed, on
   const isCollapsible = status === 'COMPLETED' || status === 'FAILED';
 
   const borderColor = getBorderColor(status);
+  const expertColor = getExpertColor(displayId);
 
   return (
     <div className={`bg-[var(--surface-2)] border ${borderColor} rounded-lg shadow-lg transition-all duration-300 flex flex-col`}>
       <div className="p-4 border-b border-[var(--line)] flex justify-between items-center gap-2">
         <div className="flex items-center space-x-3 overflow-hidden">
-          <SparklesIcon className="h-5 w-5 text-[var(--accent)] flex-shrink-0" aria-hidden="true" />
+          <SparklesIcon className="h-5 w-5 flex-shrink-0" style={{ color: expertColor }} aria-hidden="true" />
           <h3 className="font-bold text-sm text-[var(--text)] truncate">Agent {displayId}</h3>
           <span className={`text-xs font-bold px-2 py-0.5 rounded-full uppercase ${getProviderChipStyle(provider)}`}>
               {provider}

--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useId } from 'react';
+import React, { useId } from 'react';
 import { AgentState, AgentStatus } from '@/types';
 import {
     LoadingSpinner,
@@ -13,64 +13,65 @@ import {
 interface AgentCardProps {
   agent: AgentState;
   displayId: number;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
 }
 
 const getStatusIndicator = (status: AgentStatus): React.ReactNode => {
     switch (status) {
         case 'RUNNING':
-            return <><LoadingSpinner className="h-5 w-5 text-blue-400 animate-spin" /><span className="sr-only">Running</span></>;
+            return <><LoadingSpinner className="h-5 w-5 text-[var(--accent-2)] animate-spin" /><span className="sr-only">Running</span></>;
         case 'COMPLETED':
-            return <><CheckCircleIcon className="h-5 w-5 text-green-400" /><span className="sr-only">Completed</span></>;
+            return <><CheckCircleIcon className="h-5 w-5 text-[var(--success)]" /><span className="sr-only">Completed</span></>;
         case 'FAILED':
-            return <><XCircleIcon className="h-5 w-5 text-red-400" /><span className="sr-only">Failed</span></>;
+            return <><XCircleIcon className="h-5 w-5 text-[var(--danger)]" /><span className="sr-only">Failed</span></>;
         case 'PENDING':
         default:
-            return <><EllipsisHorizontalIcon className="h-5 w-5 text-gray-500" /><span className="sr-only">Pending</span></>;
+            return <><EllipsisHorizontalIcon className="h-5 w-5 text-[var(--text-muted)]" /><span className="sr-only">Pending</span></>;
     }
 };
 
 const getBorderColor = (status: AgentStatus): string => {
     switch(status) {
         case 'RUNNING':
-            return 'border-blue-500 animate-pulse';
+            return 'border-[var(--accent-2)] animate-pulse';
         case 'COMPLETED':
-            return 'border-green-500';
+            return 'border-[var(--success)]';
         case 'FAILED':
-            return 'border-red-500';
+            return 'border-[var(--danger)]';
         case 'PENDING':
         default:
-            return 'border-gray-600';
+            return 'border-[var(--line)]';
     }
 };
 
 const getProviderChipStyle = (provider: AgentState['provider']): string => {
     switch (provider) {
         case 'gemini':
-            return 'bg-purple-800 text-purple-200';
+            return 'bg-[var(--accent)] text-[#0D1411]';
         case 'openai':
-            return 'bg-teal-800 text-teal-200';
+            return 'bg-[var(--accent-2)] text-[#0D1411]';
         case 'openrouter':
-            return 'bg-cyan-800 text-cyan-200';
+            return 'bg-[var(--success)] text-[#0D1411]';
         default:
-            return 'bg-gray-700 text-gray-200';
+            return 'bg-[var(--surface-1)] text-[var(--text)]';
     }
 };
 
-const AgentCard: React.FC<AgentCardProps> = ({ agent, displayId }) => {
+const AgentCard: React.FC<AgentCardProps> = ({ agent, displayId, isCollapsed, onToggleCollapse }) => {
   const { persona, status, content, provider } = agent;
   const contentId = useId();
 
   const isCollapsible = status === 'COMPLETED' || status === 'FAILED';
-  const [isCollapsed, setIsCollapsed] = useState(false);
 
   const borderColor = getBorderColor(status);
 
   return (
-    <div className={`bg-gray-800/50 border ${borderColor} rounded-lg shadow-lg transition-all duration-300 flex flex-col`}>
-      <div className="p-4 border-b border-gray-700 flex justify-between items-center gap-2">
+    <div className={`bg-[var(--surface-2)] border ${borderColor} rounded-lg shadow-lg transition-all duration-300 flex flex-col`}>
+      <div className="p-4 border-b border-[var(--line)] flex justify-between items-center gap-2">
         <div className="flex items-center space-x-3 overflow-hidden">
-          <SparklesIcon className="h-5 w-5 text-purple-400 flex-shrink-0" />
-          <h3 className="font-bold text-sm text-gray-200 truncate">Agent {displayId}</h3>
+          <SparklesIcon className="h-5 w-5 text-[var(--accent)] flex-shrink-0" />
+          <h3 className="font-bold text-sm text-[var(--text)] truncate">Agent {displayId}</h3>
           <span className={`text-xs font-bold px-2 py-0.5 rounded-full uppercase ${getProviderChipStyle(provider)}`}>
               {provider}
           </span>
@@ -79,8 +80,8 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, displayId }) => {
             {getStatusIndicator(status)}
             {isCollapsible && (
                 <button
-                    onClick={() => setIsCollapsed(!isCollapsed)}
-                    className="p-1 rounded-full text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    onClick={onToggleCollapse}
+                    className="p-1 rounded-full text-[var(--text-muted)] hover:bg-[var(--surface-active)] hover:text-[var(--text)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
                     aria-expanded={!isCollapsed}
                     aria-controls={contentId}
                     title={isCollapsed ? 'Expand' : 'Collapse'}
@@ -100,8 +101,8 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, displayId }) => {
         className={`overflow-y-auto transition-all duration-500 ease-in-out ${isCollapsed ? 'max-h-0' : 'max-h-[500px]'}`}
       >
         <div className="p-4">
-            <p className="text-xs text-gray-400 italic mb-3">Persona: {persona}</p>
-            <p className="text-sm text-gray-300 whitespace-pre-wrap font-mono">{content || 'Awaiting task...'}</p>
+            <p className="text-xs text-[var(--text-muted)] italic mb-3">Persona: {persona}</p>
+            <p className="text-sm text-[var(--text)] whitespace-pre-wrap font-mono">{content || 'Awaiting task...'}</p>
         </div>
       </div>
     </div>

--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -70,7 +70,7 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, displayId, isCollapsed, on
     <div className={`bg-[var(--surface-2)] border ${borderColor} rounded-lg shadow-lg transition-all duration-300 flex flex-col`}>
       <div className="p-4 border-b border-[var(--line)] flex justify-between items-center gap-2">
         <div className="flex items-center space-x-3 overflow-hidden">
-          <SparklesIcon className="h-5 w-5 text-[var(--accent)] flex-shrink-0" />
+          <SparklesIcon className="h-5 w-5 text-[var(--accent)] flex-shrink-0" aria-hidden="true" />
           <h3 className="font-bold text-sm text-[var(--text)] truncate">Agent {displayId}</h3>
           <span className={`text-xs font-bold px-2 py-0.5 rounded-full uppercase ${getProviderChipStyle(provider)}`}>
               {provider}
@@ -87,9 +87,9 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, displayId, isCollapsed, on
                     title={isCollapsed ? 'Expand' : 'Collapse'}
                 >
                     {isCollapsed ? (
-                        <ChevronDownIcon className="h-5 w-5" />
+                        <ChevronDownIcon className="h-5 w-5" aria-hidden="true" />
                     ) : (
-                        <ChevronUpIcon className="h-5 w-5" />
+                        <ChevronUpIcon className="h-5 w-5" aria-hidden="true" />
                     )}
                     <span className="sr-only">{isCollapsed ? 'Expand card' : 'Collapse card'}</span>
                 </button>

--- a/components/AgentConfigCard.tsx
+++ b/components/AgentConfigCard.tsx
@@ -14,6 +14,8 @@ interface AgentConfigCardProps {
   displayId: number;
 }
 
+const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
+
 const getStatusIndicator = (status: AgentStatus): React.ReactNode => {
     switch (status) {
         case 'RUNNING':
@@ -199,7 +201,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 type="number"
                                 id={`traces-${config.id}`}
                                 value={config.settings.traceCount}
-                                onCommit={(value) => handleSettingChange({ traceCount: value })}
+                                onCommit={(value) => handleSettingChange({ traceCount: clamp(value, 2, 32) })}
                                 parser={(v) => parseInt(v, 10)}
                                 disabled={disabled}
                                 min="2" max="32" step="1"
@@ -239,7 +241,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 type="number"
                                 id={`tau-${config.id}`}
                                 value={config.settings.tau}
-                                onCommit={(value) => handleSettingChange({ tau: value })}
+                                onCommit={(value) => handleSettingChange({ tau: clamp(value, 0.5, 1.0) })}
                                 parser={(v) => parseFloat(v)}
                                 disabled={disabled}
                                 min="0.5" max="1.0" step="0.01"
@@ -253,7 +255,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 type="number"
                                 id={`groupWindow-${config.id}`}
                                 value={config.settings.groupWindow}
-                                onCommit={(value) => handleSettingChange({ groupWindow: value })}
+                                onCommit={(value) => handleSettingChange({ groupWindow: clamp(value, 8, 4096) })}
                                 parser={(v) => parseInt(v, 10)}
                                 disabled={disabled}
                                 min="8" max="4096" step="8"
@@ -319,19 +321,19 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                      <div className="col-span-2 grid grid-cols-2 gap-3">
                         <div>
                          <label htmlFor={`or-temp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Temperature</label>
-                             <NumericInput type="number" id={`or-temp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).temperature} onCommit={(value) => handleSettingChange({ temperature: value })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-temp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).temperature} onCommit={(value) => handleSettingChange({ temperature: clamp(value, 0, 2) })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                         <div>
                              <label htmlFor={`or-topk-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Top K</label>
-                             <NumericInput type="number" id={`or-topk-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topK} onCommit={(value) => handleSettingChange({ topK: value })} parser={(v) => parseInt(v, 10)} disabled={disabled} min="1" step="1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-topk-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topK} onCommit={(value) => handleSettingChange({ topK: Math.max(1, value) })} parser={(v) => parseInt(v, 10)} disabled={disabled} min="1" step="1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                          <div>
                              <label htmlFor={`or-topp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Top P</label>
-                             <NumericInput type="number" id={`or-topp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topP} onCommit={(value) => handleSettingChange({ topP: value })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="1" step="0.05" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-topp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topP} onCommit={(value) => handleSettingChange({ topP: clamp(value, 0, 1) })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="1" step="0.05" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                          <div>
                              <label htmlFor={`or-repp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Repetition Penalty</label>
-                             <NumericInput type="number" id={`or-repp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).repetitionPenalty} onCommit={(value) => handleSettingChange({ repetitionPenalty: value })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-repp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).repetitionPenalty} onCommit={(value) => handleSettingChange({ repetitionPenalty: clamp(value, 0, 2) })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                     </div>
                 )}

--- a/components/AgentConfigCard.tsx
+++ b/components/AgentConfigCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { AgentConfig, AgentModel, GeminiAgentConfig, GeminiAgentSettings, OpenAIAgentConfig, OpenAIAgentSettings, AgentStatus, GeminiModel, OpenAIModel, GeminiThinkingEffort, GenerationStrategy, OpenRouterAgentConfig, OpenRouterAgentSettings, OpenRouterModel } from '@/types';
 import { GEMINI_FLASH_MODEL, GEMINI_PRO_MODEL, OPENAI_AGENT_MODEL, OPENAI_GPT5_MINI_MODEL, OPENROUTER_CLAUDE_3_HAIKU, OPENROUTER_GEMINI_FLASH_1_5, OPENROUTER_GPT_4O } from '@/constants';
 import { XCircleIcon, LoadingSpinner, CheckCircleIcon, DocumentDuplicateIcon } from '@/components/icons';
+import { getExpertColor } from '@/lib/colors';
 
 interface AgentConfigCardProps {
   config: AgentConfig;
@@ -9,6 +10,7 @@ interface AgentConfigCardProps {
   onRemove: (id:string) => void;
   onDuplicate: (id: string) => void;
   disabled: boolean;
+  displayId: number;
 }
 
 const getStatusIndicator = (status: AgentStatus): React.ReactNode => {
@@ -41,7 +43,7 @@ const getBorderColor = (status: AgentStatus): string => {
     }
 }
 
-const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onRemove, onDuplicate, disabled }) => {
+const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onRemove, onDuplicate, disabled, displayId }) => {
     
     const handleModelChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const newModelValue = e.target.value as AgentModel;
@@ -107,12 +109,13 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
     };
     
     const borderColor = getBorderColor(config.status);
+    const expertColor = getExpertColor(displayId);
 
     return (
         <div className={`relative group bg-[var(--surface-2)] p-4 rounded-lg border transition-all duration-300 ${borderColor}`}>
             <div className="flex justify-between items-start">
                 <div>
-                    <h4 className="font-bold text-[var(--text)]">{config.expert.name}</h4>
+                    <h4 className="font-bold" style={{ color: expertColor }}>{config.expert.name}</h4>
                     <p className="text-xs text-[var(--text-muted)] italic mt-1 pr-8">Persona: {config.expert.persona}</p>
                 </div>
                 <div className="flex-shrink-0">

--- a/components/AgentConfigCard.tsx
+++ b/components/AgentConfigCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AgentConfig, AgentModel, GeminiAgentConfig, GeminiAgentSettings, OpenAIAgentConfig, OpenAIAgentSettings, AgentStatus, GeminiModel, OpenAIModel, GeminiThinkingEffort, GenerationStrategy, OpenRouterAgentConfig, OpenRouterAgentSettings, OpenRouterModel } from '@/types';
-import { GEMINI_FLASH_MODEL, GEMINI_PRO_MODEL, OPENAI_AGENT_MODEL, OPENROUTER_CLAUDE_3_HAIKU, OPENROUTER_GEMINI_FLASH_1_5, OPENROUTER_GPT_4O } from '@/constants';
+import { GEMINI_FLASH_MODEL, GEMINI_PRO_MODEL, OPENAI_AGENT_MODEL, OPENAI_GPT5_MINI_MODEL, OPENROUTER_CLAUDE_3_HAIKU, OPENROUTER_GEMINI_FLASH_1_5, OPENROUTER_GPT_4O } from '@/constants';
 import { XCircleIcon, LoadingSpinner, CheckCircleIcon, DocumentDuplicateIcon } from '@/components/icons';
 
 interface AgentConfigCardProps {
@@ -14,11 +14,11 @@ interface AgentConfigCardProps {
 const getStatusIndicator = (status: AgentStatus): React.ReactNode => {
     switch (status) {
         case 'RUNNING':
-            return <LoadingSpinner className="h-5 w-5 text-blue-400 animate-spin" />;
+            return <LoadingSpinner className="h-5 w-5 text-[var(--accent-2)] animate-spin" />;
         case 'COMPLETED':
-            return <CheckCircleIcon className="h-5 w-5 text-green-400" />;
+            return <CheckCircleIcon className="h-5 w-5 text-[var(--success)]" />;
         case 'FAILED':
-            return <XCircleIcon className="h-5 w-5 text-red-400" />;
+            return <XCircleIcon className="h-5 w-5 text-[var(--danger)]" />;
         case 'PENDING':
         case 'QUEUED':
         default:
@@ -29,15 +29,15 @@ const getStatusIndicator = (status: AgentStatus): React.ReactNode => {
 const getBorderColor = (status: AgentStatus): string => {
     switch(status) {
         case 'RUNNING':
-            return 'border-blue-500/80 ring-2 ring-blue-500/50';
+            return 'border-[var(--accent-2)] ring-2 ring-[var(--accent-2)] ring-opacity-50';
         case 'COMPLETED':
-            return 'border-green-500/80';
+            return 'border-[var(--success)]';
         case 'FAILED':
-            return 'border-red-500/80';
+            return 'border-[var(--danger)]';
         case 'PENDING':
         case 'QUEUED':
         default:
-            return 'border-gray-600';
+            return 'border-[var(--line)]';
     }
 }
 
@@ -109,11 +109,11 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
     const borderColor = getBorderColor(config.status);
 
     return (
-        <div className={`relative group bg-gray-800/50 p-4 rounded-lg border transition-all duration-300 ${borderColor}`}>
+        <div className={`relative group bg-[var(--surface-2)] p-4 rounded-lg border transition-all duration-300 ${borderColor}`}>
             <div className="flex justify-between items-start">
                 <div>
-                    <h4 className="font-bold text-gray-200">{config.expert.name}</h4>
-                    <p className="text-xs text-gray-400 italic mt-1 pr-8">Persona: {config.expert.persona}</p>
+                    <h4 className="font-bold text-[var(--text)]">{config.expert.name}</h4>
+                    <p className="text-xs text-[var(--text-muted)] italic mt-1 pr-8">Persona: {config.expert.persona}</p>
                 </div>
                 <div className="flex-shrink-0">
                     {getStatusIndicator(config.status)}
@@ -126,7 +126,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                 <button 
                     onClick={() => onDuplicate(config.id)} 
                     disabled={disabled} 
-                    className="p-1 text-gray-400 hover:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="p-1 text-[var(--text-muted)] hover:text-[var(--text)] disabled:opacity-50 disabled:cursor-not-allowed"
                     title="Duplicate Agent"
                 >
                     <DocumentDuplicateIcon className="w-5 h-5" />
@@ -135,7 +135,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                 <button 
                     onClick={() => onRemove(config.id)} 
                     disabled={disabled} 
-                    className="p-1 text-gray-400 hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="p-1 text-[var(--text-muted)] hover:text-[var(--danger)] disabled:opacity-50 disabled:cursor-not-allowed"
                     title="Remove Agent"
                 >
                     <XCircleIcon className="w-5 h-5" />
@@ -146,13 +146,13 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
 
             <div className="mt-4 grid grid-cols-2 gap-3">
                 <div>
-                    <label htmlFor={`model-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Model</label>
+                    <label htmlFor={`model-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Model</label>
                     <select
                         id={`model-${config.id}`}
                         value={config.model}
                         onChange={handleModelChange}
                         disabled={disabled}
-                        className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500"
+                        className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
                     >
                         <optgroup label="Google">
                             <option value={GEMINI_PRO_MODEL}>Gemini 2.5 Pro</option>
@@ -160,6 +160,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                         </optgroup>
                         <optgroup label="OpenAI">
                              <option value={OPENAI_AGENT_MODEL}>OpenAI GPT-5</option>
+                             <option value={OPENAI_GPT5_MINI_MODEL}>OpenAI GPT-5 Mini</option>
                         </optgroup>
                         <optgroup label="OpenRouter">
                             <option value={OPENROUTER_GPT_4O}>OpenAI GPT-4o</option>
@@ -170,13 +171,13 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                 </div>
 
                 <div>
-                     <label htmlFor={`strategy-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Generation Strategy</label>
+                     <label htmlFor={`strategy-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Generation Strategy</label>
                     <select
                         id={`strategy-${config.id}`}
                         value={config.provider === 'openrouter' ? 'single' : (config as GeminiAgentConfig | OpenAIAgentConfig).settings.generationStrategy}
                         onChange={(e) => handleSettingChange({ generationStrategy: e.target.value as GenerationStrategy })}
                         disabled={disabled || config.provider === 'openrouter'}
-                        className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500 disabled:opacity-70"
+                        className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)] disabled:opacity-70"
                         title={config.provider === 'openrouter' ? "DeepConf is not currently supported for OpenRouter agents." : "Select the generation strategy."}
                     >
                         <option value="single">Single Draft</option>
@@ -188,7 +189,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                 {config.provider !== 'openrouter' && config.settings.generationStrategy !== 'single' &&
                     <>
                         <div>
-                            <label htmlFor={`traces-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Trace Count</label>
+                            <label htmlFor={`traces-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Trace Count</label>
                             <input
                                 type="number"
                                 id={`traces-${config.id}`}
@@ -196,18 +197,18 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 onChange={(e) => handleSettingChange({ traceCount: parseInt(e.target.value, 10) })}
                                 disabled={disabled}
                                 min="2" max="32" step="1"
-                                className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500"
+                                className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
                                 title="Number of parallel responses to generate for DeepConf."
                             />
                         </div>
                         <div>
-                            <label htmlFor={`eta-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Confidence (Eta)</label>
+                            <label htmlFor={`eta-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Confidence (Eta)</label>
                             <select
                                 id={`eta-${config.id}`}
                                 value={config.settings.deepConfEta}
                                 onChange={(e) => handleSettingChange({ deepConfEta: parseInt(e.target.value, 10) as (10 | 90) })}
                                 disabled={disabled}
-                                className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500"
+                                className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
                                 title="Confidence threshold. 90% is conservative (keeps more), 10% is aggressive (keeps few high-confidence traces)."
                             >
                                 <option value="90">90% (Conservative)</option>
@@ -215,19 +216,19 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                             </select>
                         </div>
                         <div className="col-span-2">
-                             <label htmlFor={`confidence-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Confidence Source</label>
+                             <label htmlFor={`confidence-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Confidence Source</label>
                             <select
                                 id={`confidence-${config.id}`}
                                 value={config.settings.confidenceSource}
                                 disabled={true}
-                                className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500 disabled:opacity-70 disabled:cursor-not-allowed"
+                                className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)] disabled:opacity-70 disabled:cursor-not-allowed"
                                 title="Only 'Judge' is available. The underlying models (Gemini and GPT-5) do not support streaming logprobs required for token-based confidence."
                             >
                                 <option value="judge">Judge Verifier</option>
                             </select>
                         </div>
                         <div>
-                            <label htmlFor={`tau-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Consensus (Tau)</label>
+                            <label htmlFor={`tau-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Consensus (Tau)</label>
                             <input
                                 type="number"
                                 id={`tau-${config.id}`}
@@ -235,12 +236,12 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 onChange={(e) => handleSettingChange({ tau: parseFloat(e.target.value) })}
                                 disabled={disabled}
                                 min="0.5" max="1.0" step="0.01"
-                                className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500"
+                                className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
                                 title="Consensus threshold for online mode. Stops when the top answer's vote share exceeds this value (e.g., 0.95)."
                             />
                         </div>
                         <div>
-                            <label htmlFor={`groupWindow-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Group Window</label>
+                            <label htmlFor={`groupWindow-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Group Window</label>
                             <input
                                 type="number"
                                 id={`groupWindow-${config.id}`}
@@ -248,7 +249,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 onChange={(e) => handleSettingChange({ groupWindow: parseInt(e.target.value, 10) })}
                                 disabled={disabled}
                                 min="8" max="4096" step="8"
-                                className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500"
+                                className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
                                 title="Sliding window size (in tokens) for calculating group confidence."
                             />
                         </div>
@@ -258,13 +259,13 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
 
                 {config.provider === 'gemini' ? (
                     <div className="col-span-2">
-                        <label htmlFor={`gemini-effort-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Thinking Effort</label>
+                        <label htmlFor={`gemini-effort-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Thinking Effort</label>
                         <select
                             id={`gemini-effort-${config.id}`}
                             value={config.settings.effort}
                             onChange={(e) => handleSettingChange({ effort: e.target.value as GeminiThinkingEffort })}
                             disabled={disabled}
-                            className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500"
+                            className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
                             title="Controls how much 'thinking' the Gemini model performs before answering. 'Dynamic' is recommended. 'High' can improve quality for complex tasks but increases latency. 'None' is fastest but least thorough."
                         >
                             <option value="dynamic">Dynamic</option>
@@ -277,13 +278,13 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                 ) : config.provider === 'openai' ? (
                     <div className="col-span-2 grid grid-cols-2 gap-3">
                         <div>
-                            <label htmlFor={`openai-effort-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Reasoning</label>
+                            <label htmlFor={`openai-effort-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Reasoning</label>
                              <select
                                 id={`openai-effort-${config.id}`}
                                 value={(config.settings as OpenAIAgentSettings).effort}
                                 onChange={(e) => handleSettingChange({ effort: e.target.value as OpenAIAgentSettings['effort'] })}
                                 disabled={disabled}
-                                className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500"
+                                className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
                                 title="Controls the model's reasoning process. 'High' enables more complex, step-by-step thinking, which can improve accuracy for difficult prompts. 'Medium' is faster and suitable for general tasks."
                             >
                                 <option value="high">High</option>
@@ -291,13 +292,13 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                             </select>
                         </div>
                         <div>
-                             <label htmlFor={`openai-verbosity-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Verbosity</label>
+                             <label htmlFor={`openai-verbosity-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Verbosity</label>
                              <select
                                 id={`openai-verbosity-${config.id}`}
                                 value={(config.settings as OpenAIAgentSettings).verbosity}
                                 onChange={(e) => handleSettingChange({ verbosity: e.target.value as OpenAIAgentSettings['verbosity'] })}
                                 disabled={disabled}
-                                className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500"
+                                className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
                                 title="Adjusts the length and detail of the agent's response. 'High' provides more comprehensive answers, while 'Low' is more concise."
                             >
                                 <option value="high">High</option>
@@ -309,20 +310,20 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                 ) : ( // OpenRouter Settings
                      <div className="col-span-2 grid grid-cols-2 gap-3">
                         <div>
-                             <label htmlFor={`or-temp-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Temperature</label>
-                             <input type="number" id={`or-temp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).temperature} onChange={e => handleSettingChange({ temperature: parseFloat(e.target.value) })} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500"/>
+                         <label htmlFor={`or-temp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Temperature</label>
+                             <input type="number" id={`or-temp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).temperature} onChange={e => handleSettingChange({ temperature: parseFloat(e.target.value) })} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                         <div>
-                             <label htmlFor={`or-topk-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Top K</label>
-                             <input type="number" id={`or-topk-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topK} onChange={e => handleSettingChange({ topK: parseInt(e.target.value, 10) })} disabled={disabled} min="1" step="1" className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500"/>
+                             <label htmlFor={`or-topk-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Top K</label>
+                             <input type="number" id={`or-topk-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topK} onChange={e => handleSettingChange({ topK: parseInt(e.target.value, 10) })} disabled={disabled} min="1" step="1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                          <div>
-                             <label htmlFor={`or-topp-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Top P</label>
-                             <input type="number" id={`or-topp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topP} onChange={e => handleSettingChange({ topP: parseFloat(e.target.value) })} disabled={disabled} min="0" max="1" step="0.05" className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500"/>
+                             <label htmlFor={`or-topp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Top P</label>
+                             <input type="number" id={`or-topp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topP} onChange={e => handleSettingChange({ topP: parseFloat(e.target.value) })} disabled={disabled} min="0" max="1" step="0.05" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                          <div>
-                             <label htmlFor={`or-repp-${config.id}`} className="block text-sm font-medium text-gray-400 mb-1">Repetition Penalty</label>
-                             <input type="number" id={`or-repp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).repetitionPenalty} onChange={e => handleSettingChange({ repetitionPenalty: parseFloat(e.target.value) })} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-gray-900 border border-gray-600 rounded-md focus:ring-2 focus:ring-indigo-500"/>
+                             <label htmlFor={`or-repp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Repetition Penalty</label>
+                             <input type="number" id={`or-repp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).repetitionPenalty} onChange={e => handleSettingChange({ repetitionPenalty: parseFloat(e.target.value) })} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                      </div>
                 )}

--- a/components/AgentConfigCard.tsx
+++ b/components/AgentConfigCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { AgentConfig, AgentModel, GeminiAgentConfig, GeminiAgentSettings, OpenAIAgentConfig, OpenAIAgentSettings, AgentStatus, GeminiModel, OpenAIModel, GeminiThinkingEffort, GenerationStrategy, OpenRouterAgentConfig, OpenRouterAgentSettings, OpenRouterModel } from '@/types';
 import { GEMINI_FLASH_MODEL, GEMINI_PRO_MODEL, OPENAI_AGENT_MODEL, OPENAI_GPT5_MINI_MODEL, OPENROUTER_CLAUDE_3_HAIKU, OPENROUTER_GEMINI_FLASH_1_5, OPENROUTER_GPT_4O } from '@/constants';
 import { XCircleIcon, LoadingSpinner, CheckCircleIcon, DocumentDuplicateIcon } from '@/components/icons';
+import NumericInput from './NumericInput';
 import { getExpertColor } from '@/lib/colors';
 
 interface AgentConfigCardProps {
@@ -43,44 +44,6 @@ const getBorderColor = (status: AgentStatus): string => {
     }
 }
 
-interface NumericInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> {
-    value: number;
-    onCommit: (value: number) => void;
-    parser?: (value: string) => number;
-}
-
-const NumericInput: React.FC<NumericInputProps> = ({ value, onCommit, parser = parseFloat, ...rest }) => {
-    const [inputValue, setInputValue] = React.useState<string>(String(value));
-
-    React.useEffect(() => {
-        setInputValue(String(value));
-    }, [value]);
-
-    const commit = () => {
-        const parsed = parser(inputValue);
-        if (!Number.isNaN(parsed)) {
-            onCommit(parsed);
-        } else {
-            setInputValue(String(value));
-        }
-    };
-
-    return (
-        <input
-            {...rest}
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onBlur={commit}
-            onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                    e.preventDefault();
-                    commit();
-                    (e.target as HTMLInputElement).blur();
-                }
-            }}
-        />
-    );
-};
 
 const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onRemove, onDuplicate, disabled, displayId }) => {
     

--- a/components/AgentConfigCard.tsx
+++ b/components/AgentConfigCard.tsx
@@ -311,19 +311,31 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                      <div className="col-span-2 grid grid-cols-2 gap-3">
                         <div>
                          <label htmlFor={`or-temp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Temperature</label>
-                             <input type="number" id={`or-temp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).temperature} onChange={e => handleSettingChange({ temperature: parseFloat(e.target.value) })} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <input type="number" id={`or-temp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).temperature} onChange={e => {
+                                 const value = parseFloat(e.target.value);
+                                 if (!Number.isNaN(value)) handleSettingChange({ temperature: value });
+                             }} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                         <div>
                              <label htmlFor={`or-topk-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Top K</label>
-                             <input type="number" id={`or-topk-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topK} onChange={e => handleSettingChange({ topK: parseInt(e.target.value, 10) })} disabled={disabled} min="1" step="1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <input type="number" id={`or-topk-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topK} onChange={e => {
+                                 const value = parseInt(e.target.value, 10);
+                                 if (!Number.isNaN(value)) handleSettingChange({ topK: value });
+                             }} disabled={disabled} min="1" step="1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                          <div>
                              <label htmlFor={`or-topp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Top P</label>
-                             <input type="number" id={`or-topp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topP} onChange={e => handleSettingChange({ topP: parseFloat(e.target.value) })} disabled={disabled} min="0" max="1" step="0.05" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <input type="number" id={`or-topp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topP} onChange={e => {
+                                 const value = parseFloat(e.target.value);
+                                 if (!Number.isNaN(value)) handleSettingChange({ topP: value });
+                             }} disabled={disabled} min="0" max="1" step="0.05" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                          <div>
                              <label htmlFor={`or-repp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Repetition Penalty</label>
-                             <input type="number" id={`or-repp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).repetitionPenalty} onChange={e => handleSettingChange({ repetitionPenalty: parseFloat(e.target.value) })} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <input type="number" id={`or-repp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).repetitionPenalty} onChange={e => {
+                                 const value = parseFloat(e.target.value);
+                                 if (!Number.isNaN(value)) handleSettingChange({ repetitionPenalty: value });
+                             }} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                      </div>
                 )}

--- a/components/AgentConfigCard.tsx
+++ b/components/AgentConfigCard.tsx
@@ -14,8 +14,6 @@ interface AgentConfigCardProps {
   displayId: number;
 }
 
-const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
-
 const getStatusIndicator = (status: AgentStatus): React.ReactNode => {
     switch (status) {
         case 'RUNNING':
@@ -201,7 +199,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 type="number"
                                 id={`traces-${config.id}`}
                                 value={config.settings.traceCount}
-                                onCommit={(value) => handleSettingChange({ traceCount: clamp(value, 2, 32) })}
+                                onCommit={(value) => handleSettingChange({ traceCount: value })}
                                 parser={(v) => parseInt(v, 10)}
                                 disabled={disabled}
                                 min="2" max="32" step="1"
@@ -241,7 +239,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 type="number"
                                 id={`tau-${config.id}`}
                                 value={config.settings.tau}
-                                onCommit={(value) => handleSettingChange({ tau: clamp(value, 0.5, 1.0) })}
+                                onCommit={(value) => handleSettingChange({ tau: value })}
                                 parser={(v) => parseFloat(v)}
                                 disabled={disabled}
                                 min="0.5" max="1.0" step="0.01"
@@ -255,7 +253,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 type="number"
                                 id={`groupWindow-${config.id}`}
                                 value={config.settings.groupWindow}
-                                onCommit={(value) => handleSettingChange({ groupWindow: clamp(value, 8, 4096) })}
+                                onCommit={(value) => handleSettingChange({ groupWindow: value })}
                                 parser={(v) => parseInt(v, 10)}
                                 disabled={disabled}
                                 min="8" max="4096" step="8"
@@ -321,19 +319,19 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                      <div className="col-span-2 grid grid-cols-2 gap-3">
                         <div>
                          <label htmlFor={`or-temp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Temperature</label>
-                             <NumericInput type="number" id={`or-temp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).temperature} onCommit={(value) => handleSettingChange({ temperature: clamp(value, 0, 2) })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-temp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).temperature} onCommit={(value) => handleSettingChange({ temperature: value })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                         <div>
                              <label htmlFor={`or-topk-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Top K</label>
-                             <NumericInput type="number" id={`or-topk-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topK} onCommit={(value) => handleSettingChange({ topK: Math.max(1, value) })} parser={(v) => parseInt(v, 10)} disabled={disabled} min="1" step="1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-topk-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topK} onCommit={(value) => handleSettingChange({ topK: value })} parser={(v) => parseInt(v, 10)} disabled={disabled} min="1" step="1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                          <div>
                              <label htmlFor={`or-topp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Top P</label>
-                             <NumericInput type="number" id={`or-topp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topP} onCommit={(value) => handleSettingChange({ topP: clamp(value, 0, 1) })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="1" step="0.05" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-topp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topP} onCommit={(value) => handleSettingChange({ topP: value })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="1" step="0.05" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                          <div>
                              <label htmlFor={`or-repp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Repetition Penalty</label>
-                             <NumericInput type="number" id={`or-repp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).repetitionPenalty} onCommit={(value) => handleSettingChange({ repetitionPenalty: clamp(value, 0, 2) })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-repp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).repetitionPenalty} onCommit={(value) => handleSettingChange({ repetitionPenalty: value })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                     </div>
                 )}

--- a/components/AgentConfigCard.tsx
+++ b/components/AgentConfigCard.tsx
@@ -71,6 +71,13 @@ const NumericInput: React.FC<NumericInputProps> = ({ value, onCommit, parser = p
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
             onBlur={commit}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    commit();
+                    (e.target as HTMLInputElement).blur();
+                }
+            }}
         />
     );
 };

--- a/components/AgentConfigCard.tsx
+++ b/components/AgentConfigCard.tsx
@@ -17,11 +17,11 @@ interface AgentConfigCardProps {
 const getStatusIndicator = (status: AgentStatus): React.ReactNode => {
     switch (status) {
         case 'RUNNING':
-            return <LoadingSpinner className="h-5 w-5 text-[var(--accent-2)] animate-spin" />;
+            return <LoadingSpinner className="h-5 w-5 text-[var(--accent-2)] animate-spin" aria-hidden="true" />;
         case 'COMPLETED':
-            return <CheckCircleIcon className="h-5 w-5 text-[var(--success)]" />;
+            return <CheckCircleIcon className="h-5 w-5 text-[var(--success)]" aria-hidden="true" />;
         case 'FAILED':
-            return <XCircleIcon className="h-5 w-5 text-[var(--danger)]" />;
+            return <XCircleIcon className="h-5 w-5 text-[var(--danger)]" aria-hidden="true" />;
         case 'PENDING':
         case 'QUEUED':
         default:
@@ -134,7 +134,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                     className="p-1 text-[var(--text-muted)] hover:text-[var(--text)] disabled:opacity-50 disabled:cursor-not-allowed"
                     title="Duplicate Agent"
                 >
-                    <DocumentDuplicateIcon className="w-5 h-5" />
+                    <DocumentDuplicateIcon className="w-5 h-5" aria-hidden="true" />
                     <span className="sr-only">Duplicate Agent</span>
                 </button>
                 <button 
@@ -143,7 +143,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                     className="p-1 text-[var(--text-muted)] hover:text-[var(--danger)] disabled:opacity-50 disabled:cursor-not-allowed"
                     title="Remove Agent"
                 >
-                    <XCircleIcon className="w-5 h-5" />
+                    <XCircleIcon className="w-5 h-5" aria-hidden="true" />
                     <span className="sr-only">Remove Agent</span>
                 </button>
             </div>

--- a/components/AgentConfigCard.tsx
+++ b/components/AgentConfigCard.tsx
@@ -197,7 +197,10 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 type="number"
                                 id={`traces-${config.id}`}
                                 value={config.settings.traceCount}
-                                onChange={(e) => handleSettingChange({ traceCount: parseInt(e.target.value, 10) })}
+                                onChange={(e) => {
+                                    const value = parseInt(e.target.value, 10);
+                                    if (!Number.isNaN(value)) handleSettingChange({ traceCount: value });
+                                }}
                                 disabled={disabled}
                                 min="2" max="32" step="1"
                                 className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
@@ -236,7 +239,10 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 type="number"
                                 id={`tau-${config.id}`}
                                 value={config.settings.tau}
-                                onChange={(e) => handleSettingChange({ tau: parseFloat(e.target.value) })}
+                                onChange={(e) => {
+                                    const value = parseFloat(e.target.value);
+                                    if (!Number.isNaN(value)) handleSettingChange({ tau: value });
+                                }}
                                 disabled={disabled}
                                 min="0.5" max="1.0" step="0.01"
                                 className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
@@ -249,7 +255,10 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 type="number"
                                 id={`groupWindow-${config.id}`}
                                 value={config.settings.groupWindow}
-                                onChange={(e) => handleSettingChange({ groupWindow: parseInt(e.target.value, 10) })}
+                                onChange={(e) => {
+                                    const value = parseInt(e.target.value, 10);
+                                    if (!Number.isNaN(value)) handleSettingChange({ groupWindow: value });
+                                }}
                                 disabled={disabled}
                                 min="8" max="4096" step="8"
                                 className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"

--- a/components/AgentConfigCard.tsx
+++ b/components/AgentConfigCard.tsx
@@ -43,6 +43,38 @@ const getBorderColor = (status: AgentStatus): string => {
     }
 }
 
+interface NumericInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> {
+    value: number;
+    onCommit: (value: number) => void;
+    parser?: (value: string) => number;
+}
+
+const NumericInput: React.FC<NumericInputProps> = ({ value, onCommit, parser = parseFloat, ...rest }) => {
+    const [inputValue, setInputValue] = React.useState<string>(String(value));
+
+    React.useEffect(() => {
+        setInputValue(String(value));
+    }, [value]);
+
+    const commit = () => {
+        const parsed = parser(inputValue);
+        if (!Number.isNaN(parsed)) {
+            onCommit(parsed);
+        } else {
+            setInputValue(String(value));
+        }
+    };
+
+    return (
+        <input
+            {...rest}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onBlur={commit}
+        />
+    );
+};
+
 const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onRemove, onDuplicate, disabled, displayId }) => {
     
     const handleModelChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -193,14 +225,12 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                     <>
                         <div>
                             <label htmlFor={`traces-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Trace Count</label>
-                            <input
+                            <NumericInput
                                 type="number"
                                 id={`traces-${config.id}`}
                                 value={config.settings.traceCount}
-                                onChange={(e) => {
-                                    const value = parseInt(e.target.value, 10);
-                                    if (!Number.isNaN(value)) handleSettingChange({ traceCount: value });
-                                }}
+                                onCommit={(value) => handleSettingChange({ traceCount: value })}
+                                parser={(v) => parseInt(v, 10)}
                                 disabled={disabled}
                                 min="2" max="32" step="1"
                                 className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
@@ -235,14 +265,12 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                         </div>
                         <div>
                             <label htmlFor={`tau-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Consensus (Tau)</label>
-                            <input
+                            <NumericInput
                                 type="number"
                                 id={`tau-${config.id}`}
                                 value={config.settings.tau}
-                                onChange={(e) => {
-                                    const value = parseFloat(e.target.value);
-                                    if (!Number.isNaN(value)) handleSettingChange({ tau: value });
-                                }}
+                                onCommit={(value) => handleSettingChange({ tau: value })}
+                                parser={(v) => parseFloat(v)}
                                 disabled={disabled}
                                 min="0.5" max="1.0" step="0.01"
                                 className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
@@ -251,14 +279,12 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                         </div>
                         <div>
                             <label htmlFor={`groupWindow-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Group Window</label>
-                            <input
+                            <NumericInput
                                 type="number"
                                 id={`groupWindow-${config.id}`}
                                 value={config.settings.groupWindow}
-                                onChange={(e) => {
-                                    const value = parseInt(e.target.value, 10);
-                                    if (!Number.isNaN(value)) handleSettingChange({ groupWindow: value });
-                                }}
+                                onCommit={(value) => handleSettingChange({ groupWindow: value })}
+                                parser={(v) => parseInt(v, 10)}
                                 disabled={disabled}
                                 min="8" max="4096" step="8"
                                 className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"
@@ -323,33 +349,21 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                      <div className="col-span-2 grid grid-cols-2 gap-3">
                         <div>
                          <label htmlFor={`or-temp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Temperature</label>
-                             <input type="number" id={`or-temp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).temperature} onChange={e => {
-                                 const value = parseFloat(e.target.value);
-                                 if (!Number.isNaN(value)) handleSettingChange({ temperature: value });
-                             }} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-temp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).temperature} onCommit={(value) => handleSettingChange({ temperature: value })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                         <div>
                              <label htmlFor={`or-topk-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Top K</label>
-                             <input type="number" id={`or-topk-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topK} onChange={e => {
-                                 const value = parseInt(e.target.value, 10);
-                                 if (!Number.isNaN(value)) handleSettingChange({ topK: value });
-                             }} disabled={disabled} min="1" step="1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-topk-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topK} onCommit={(value) => handleSettingChange({ topK: value })} parser={(v) => parseInt(v, 10)} disabled={disabled} min="1" step="1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                          <div>
                              <label htmlFor={`or-topp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Top P</label>
-                             <input type="number" id={`or-topp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topP} onChange={e => {
-                                 const value = parseFloat(e.target.value);
-                                 if (!Number.isNaN(value)) handleSettingChange({ topP: value });
-                             }} disabled={disabled} min="0" max="1" step="0.05" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-topp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topP} onCommit={(value) => handleSettingChange({ topP: value })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="1" step="0.05" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                          <div>
                              <label htmlFor={`or-repp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Repetition Penalty</label>
-                             <input type="number" id={`or-repp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).repetitionPenalty} onChange={e => {
-                                 const value = parseFloat(e.target.value);
-                                 if (!Number.isNaN(value)) handleSettingChange({ repetitionPenalty: value });
-                             }} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-repp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).repetitionPenalty} onCommit={(value) => handleSettingChange({ repetitionPenalty: value })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
-                     </div>
+                    </div>
                 )}
             </div>
         </div>

--- a/components/AgentEnsemble.tsx
+++ b/components/AgentEnsemble.tsx
@@ -100,7 +100,7 @@ const AgentEnsemble = forwardRef<AgentEnsembleHandles, AgentEnsembleProps>(({ ag
             />
         </div>
     );
-};
+});
 
 AgentEnsemble.displayName = 'AgentEnsemble';
 

--- a/components/AgentEnsemble.tsx
+++ b/components/AgentEnsemble.tsx
@@ -1,7 +1,7 @@
 
 
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useImperativeHandle, forwardRef } from 'react';
 import { experts } from '@/moe/experts';
 import { AgentConfig, GeminiAgentConfig, Expert } from '@/types';
 import AgentConfigCard from '@/components/AgentConfigCard';
@@ -13,17 +13,18 @@ interface AgentEnsembleProps {
     setAgentConfigs: React.Dispatch<React.SetStateAction<AgentConfig[]>>;
     onDuplicateAgent: (id: string) => void;
     disabled: boolean;
-    registerOpenModal?: (open: () => void) => void;
 }
 
-const AgentEnsemble: React.FC<AgentEnsembleProps> = ({ agentConfigs, setAgentConfigs, onDuplicateAgent, disabled, registerOpenModal }) => {
+export interface AgentEnsembleHandles {
+    openModal: () => void;
+}
+
+const AgentEnsemble = forwardRef<AgentEnsembleHandles, AgentEnsembleProps>(({ agentConfigs, setAgentConfigs, onDuplicateAgent, disabled }, ref) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
 
-    useEffect(() => {
-        if (registerOpenModal) {
-            registerOpenModal(() => setIsModalOpen(true));
-        }
-    }, [registerOpenModal]);
+    useImperativeHandle(ref, () => ({
+        openModal: () => setIsModalOpen(true),
+    }));
 
     const handleAddAgent = (expert: Expert) => {
         const newAgent: GeminiAgentConfig = {

--- a/components/AgentEnsemble.tsx
+++ b/components/AgentEnsemble.tsx
@@ -1,7 +1,7 @@
 
 
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { experts } from '@/moe/experts';
 import { AgentConfig, GeminiAgentConfig, Expert } from '@/types';
 import AgentConfigCard from '@/components/AgentConfigCard';
@@ -13,10 +13,17 @@ interface AgentEnsembleProps {
     setAgentConfigs: React.Dispatch<React.SetStateAction<AgentConfig[]>>;
     onDuplicateAgent: (id: string) => void;
     disabled: boolean;
+    registerOpenModal?: (open: () => void) => void;
 }
 
-const AgentEnsemble: React.FC<AgentEnsembleProps> = ({ agentConfigs, setAgentConfigs, onDuplicateAgent, disabled }) => {
+const AgentEnsemble: React.FC<AgentEnsembleProps> = ({ agentConfigs, setAgentConfigs, onDuplicateAgent, disabled, registerOpenModal }) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
+
+    useEffect(() => {
+        if (registerOpenModal) {
+            registerOpenModal(() => setIsModalOpen(true));
+        }
+    }, [registerOpenModal]);
 
     const handleAddAgent = (expert: Expert) => {
         const newAgent: GeminiAgentConfig = {
@@ -51,12 +58,12 @@ const AgentEnsemble: React.FC<AgentEnsembleProps> = ({ agentConfigs, setAgentCon
     return (
         <div className="space-y-4">
             <div className="flex items-center justify-between">
-                <h3 className="text-base font-medium text-gray-200">Agent Ensemble</h3>
+                <h3 className="text-base font-medium text-[var(--text)]">Agent Ensemble</h3>
                 {availableExperts.length > 0 && (
                     <button
                         onClick={() => setIsModalOpen(true)}
                         disabled={disabled}
-                        className="flex items-center justify-center gap-2 px-3 py-1 bg-gray-700/80 text-white text-sm font-semibold rounded-lg shadow-md hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="flex items-center justify-center gap-2 px-3 py-1 bg-[var(--accent)] text-[#0D1411] text-sm font-semibold rounded-lg shadow-md hover:brightness-110 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                         <PlusIcon className="w-4 h-4" />
                         Add Expert

--- a/components/AgentEnsemble.tsx
+++ b/components/AgentEnsemble.tsx
@@ -65,7 +65,7 @@ const AgentEnsemble: React.FC<AgentEnsembleProps> = ({ agentConfigs, setAgentCon
                         disabled={disabled}
                         className="flex items-center justify-center gap-2 px-3 py-1 bg-[var(--accent)] text-[#0D1411] text-sm font-semibold rounded-lg shadow-md hover:brightness-110 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                        <PlusIcon className="w-4 h-4" />
+                        <PlusIcon className="w-4 h-4" aria-hidden="true" />
                         Add Expert
                     </button>
                 )}

--- a/components/AgentEnsemble.tsx
+++ b/components/AgentEnsemble.tsx
@@ -73,17 +73,23 @@ const AgentEnsemble = forwardRef<AgentEnsembleHandles, AgentEnsembleProps>(({ ag
             </div>
             
             <div className="space-y-3 max-h-[40vh] overflow-y-auto pr-2">
-                {agentConfigs.map((config, idx) => (
-                    <AgentConfigCard
-                        key={config.id}
-                        config={config}
-                        onUpdate={handleUpdateAgent}
-                        onRemove={handleRemoveAgent}
-                        onDuplicate={onDuplicateAgent}
-                        disabled={disabled}
-                        displayId={idx + 1}
-                    />
-                ))}
+                {agentConfigs.length > 0 ? (
+                    agentConfigs.map((config, idx) => (
+                        <AgentConfigCard
+                            key={config.id}
+                            config={config}
+                            onUpdate={handleUpdateAgent}
+                            onRemove={handleRemoveAgent}
+                            onDuplicate={onDuplicateAgent}
+                            disabled={disabled}
+                            displayId={idx + 1}
+                        />
+                    ))
+                ) : (
+                    <div className="flex items-center justify-center h-24 text-sm text-[var(--text-muted)]">
+                        No experts configured. Click "Add Expert" to get started.
+                    </div>
+                )}
             </div>
 
              <AddExpertModal

--- a/components/AgentEnsemble.tsx
+++ b/components/AgentEnsemble.tsx
@@ -102,4 +102,6 @@ const AgentEnsemble = forwardRef<AgentEnsembleHandles, AgentEnsembleProps>(({ ag
     );
 };
 
+AgentEnsemble.displayName = 'AgentEnsemble';
+
 export default AgentEnsemble;

--- a/components/AgentEnsemble.tsx
+++ b/components/AgentEnsemble.tsx
@@ -72,7 +72,7 @@ const AgentEnsemble: React.FC<AgentEnsembleProps> = ({ agentConfigs, setAgentCon
             </div>
             
             <div className="space-y-3 max-h-[40vh] overflow-y-auto pr-2">
-                {agentConfigs.map(config => (
+                {agentConfigs.map((config, idx) => (
                     <AgentConfigCard
                         key={config.id}
                         config={config}
@@ -80,6 +80,7 @@ const AgentEnsemble: React.FC<AgentEnsembleProps> = ({ agentConfigs, setAgentCon
                         onRemove={handleRemoveAgent}
                         onDuplicate={onDuplicateAgent}
                         disabled={disabled}
+                        displayId={idx + 1}
                     />
                 ))}
             </div>

--- a/components/CollapsibleSection.tsx
+++ b/components/CollapsibleSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useId } from 'react';
 import { ChevronUpIcon, ChevronDownIcon } from './icons';
 
 interface CollapsibleSectionProps {
@@ -10,6 +10,7 @@ interface CollapsibleSectionProps {
 
 const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ title, children, isDisabled = false, defaultOpen = false }) => {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   const toggleOpen = () => {
     if (!isDisabled) {
@@ -25,15 +26,16 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ title, children
         disabled={isDisabled}
         className="w-full flex justify-between items-center p-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-1)] rounded-t-lg"
         aria-expanded={isOpen}
+        aria-controls={contentId}
       >
         <h4 className="text-base font-medium text-[var(--text)]">{title}</h4>
         {isOpen ? (
-          <ChevronUpIcon className="w-5 h-5 text-[var(--text-muted)]" />
+          <ChevronUpIcon className="w-5 h-5 text-[var(--text-muted)]" aria-hidden="true" />
         ) : (
-          <ChevronDownIcon className="w-5 h-5 text-[var(--text-muted)]" />
+          <ChevronDownIcon className="w-5 h-5 text-[var(--text-muted)]" aria-hidden="true" />
         )}
       </button>
-      <div className={`overflow-hidden transition-all duration-300 ease-in-out ${isOpen ? 'max-h-[1000px]' : 'max-h-0'}`}>
+      <div id={contentId} className={`overflow-hidden transition-all duration-300 ease-in-out ${isOpen ? 'max-h-[1000px]' : 'max-h-0'}`}>
         <div className="p-4 border-t border-[var(--line)]">
             {children}
         </div>

--- a/components/CollapsibleSection.tsx
+++ b/components/CollapsibleSection.tsx
@@ -18,23 +18,23 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ title, children
   };
 
   return (
-    <div className={`border border-gray-700 rounded-lg transition-opacity ${isDisabled ? 'opacity-50' : ''}`}>
+    <div className={`border border-[var(--line)] rounded-lg transition-opacity ${isDisabled ? 'opacity-50' : ''}`}>
       <button
         type="button"
         onClick={toggleOpen}
         disabled={isDisabled}
-        className="w-full flex justify-between items-center p-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 rounded-t-lg"
+        className="w-full flex justify-between items-center p-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-1)] rounded-t-lg"
         aria-expanded={isOpen}
       >
-        <h4 className="text-base font-medium text-gray-200">{title}</h4>
+        <h4 className="text-base font-medium text-[var(--text)]">{title}</h4>
         {isOpen ? (
-          <ChevronUpIcon className="w-5 h-5 text-gray-400" />
+          <ChevronUpIcon className="w-5 h-5 text-[var(--text-muted)]" />
         ) : (
-          <ChevronDownIcon className="w-5 h-5 text-gray-400" />
+          <ChevronDownIcon className="w-5 h-5 text-[var(--text-muted)]" />
         )}
       </button>
       <div className={`overflow-hidden transition-all duration-300 ease-in-out ${isOpen ? 'max-h-[1000px]' : 'max-h-0'}`}>
-        <div className="p-4 border-t border-gray-700">
+        <div className="p-4 border-t border-[var(--line)]">
             {children}
         </div>
       </div>

--- a/components/CollapsibleSection.tsx
+++ b/components/CollapsibleSection.tsx
@@ -35,7 +35,7 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ title, children
           <ChevronDownIcon className="w-5 h-5 text-[var(--text-muted)]" aria-hidden="true" />
         )}
       </button>
-      <div id={contentId} className={`overflow-hidden transition-all duration-300 ease-in-out ${isOpen ? 'max-h-[1000px]' : 'max-h-0'}`}>
+      <div id={contentId} className={`overflow-hidden transition-all duration-300 ease-in-out ${isOpen ? 'max-h-screen' : 'max-h-0'}`}>
         <div className="p-4 border-t border-[var(--line)]">
             {children}
         </div>

--- a/components/FinalAnswerCard.tsx
+++ b/components/FinalAnswerCard.tsx
@@ -66,24 +66,24 @@ const FinalAnswerCard: React.FC<FinalAnswerCardProps> = ({ answer, title = "Arbi
 
   return (
     <div className={`final-answer-glow rounded-xl shadow-2xl ${className}`} {...rest}>
-      <div className="bg-gray-800/50 p-0 rounded-xl flex flex-col w-full min-h-[200px]">
+      <div className="bg-[var(--surface-2)] p-0 rounded-xl flex flex-col w-full min-h-[200px]">
         {/* Header */}
-        <div className="p-4 border-b border-gray-700 flex items-center justify-between gap-3 flex-shrink-0">
+        <div className="p-4 border-b border-[var(--line)] flex items-center justify-between gap-3 flex-shrink-0">
             <div className="flex items-center gap-3">
-                <SparklesIcon className="w-6 h-6 text-indigo-400"/>
-                <h2 className="text-xl font-bold text-gray-200">{title}</h2>
+                <SparklesIcon className="w-6 h-6 text-[var(--accent)]"/>
+                <h2 className="text-xl font-bold text-[var(--text)]">{title}</h2>
             </div>
         </div>
         {/* Content */}
         <div className="p-4 flex-grow min-h-0 overflow-y-auto max-h-[70vh]">
             {hasContent ? (
-                <p className="text-gray-200 whitespace-pre-wrap font-serif leading-relaxed">
+                <p className="text-[var(--text)] whitespace-pre-wrap font-serif leading-relaxed">
                     {displayedAnswer}
-                    {showCursor && <span className="inline-block w-2 h-5 bg-indigo-400 animate-pulse ml-1" />}
+                    {showCursor && <span className="inline-block w-2 h-5 bg-[var(--accent)] animate-pulse ml-1" />}
                 </p>
             ) : (
                 <div className="flex items-center justify-center h-full">
-                    <p className="text-gray-500 italic">Waiting for arbiter's response...</p>
+                    <p className="text-[var(--text-muted)] italic">Waiting for arbiter's response...</p>
                 </div>
             )}
         </div>

--- a/components/FinalAnswerCard.tsx
+++ b/components/FinalAnswerCard.tsx
@@ -70,7 +70,7 @@ const FinalAnswerCard: React.FC<FinalAnswerCardProps> = ({ answer, title = "Arbi
         {/* Header */}
         <div className="p-4 border-b border-[var(--line)] flex items-center justify-between gap-3 flex-shrink-0">
             <div className="flex items-center gap-3">
-                <SparklesIcon className="w-6 h-6 text-[var(--accent)]"/>
+                <SparklesIcon className="w-6 h-6 text-[var(--accent)]" aria-hidden="true"/>
                 <h2 className="text-xl font-bold text-[var(--text)]">{title}</h2>
             </div>
         </div>

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -116,7 +116,6 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
                                     className={`w-full text-left flex items-center gap-3 p-2 rounded-md transition-colors ${
                                         selectedRunId === run.id ? 'bg-[var(--surface-1)]' : 'hover:bg-[var(--surface-active)]'
                                     }`}
-                                    title={run.prompt}
                                 >
                                    <div className="flex-shrink-0 w-4 h-4 flex items-center justify-center mt-0.5">
                                         <StatusIndicator status={run.status} />

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -104,27 +104,33 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
                             </button>
                         </li>
                      )}
-                    {history.map(run => (
-                        <li key={run.id}>
-                            <button
-                                onClick={() => onSelectRun(run.id)}
-                                className={`w-full text-left flex items-center gap-3 p-2 rounded-md transition-colors ${
-                                    selectedRunId === run.id ? 'bg-[var(--surface-1)]' : 'hover:bg-[var(--surface-active)]'
-                                }`}
-                                title={run.prompt}
-                            >
-                               <div className="flex-shrink-0 w-4 h-4 flex items-center justify-center mt-0.5">
-                                    <StatusIndicator status={run.status} />
-                               </div>
-                                {isOpen && (
-                                    <div className="overflow-hidden">
-                                        <p className="text-sm font-medium text-[var(--text)] truncate">{run.prompt || "Image-based prompt"}</p>
-                                        <p className="text-xs text-[var(--text-muted)]">{formatTimestamp(run.timestamp)}</p>
-                                    </div>
-                                )}
-                            </button>
+                    {history.length === 0 && currentRunStatus === 'IDLE' ? (
+                        <li className="text-center py-4 text-sm text-[var(--text-muted)]">
+                            No past runs yet. Submit a prompt to create one.
                         </li>
-                    ))}
+                    ) : (
+                        history.map(run => (
+                            <li key={run.id}>
+                                <button
+                                    onClick={() => onSelectRun(run.id)}
+                                    className={`w-full text-left flex items-center gap-3 p-2 rounded-md transition-colors ${
+                                        selectedRunId === run.id ? 'bg-[var(--surface-1)]' : 'hover:bg-[var(--surface-active)]'
+                                    }`}
+                                    title={run.prompt}
+                                >
+                                   <div className="flex-shrink-0 w-4 h-4 flex items-center justify-center mt-0.5">
+                                        <StatusIndicator status={run.status} />
+                                   </div>
+                                    {isOpen && (
+                                        <div className="overflow-hidden">
+                                            <p className="text-sm font-medium text-[var(--text)] truncate">{run.prompt || "Image-based prompt"}</p>
+                                            <p className="text-xs text-[var(--text-muted)]">{formatTimestamp(run.timestamp)}</p>
+                                        </div>
+                                    )}
+                                </button>
+                            </li>
+                        ))
+                    )}
                 </ul>
             </nav>
         </aside>

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -65,7 +65,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
                     className="p-2 text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--surface-active)] rounded-lg transition-colors"
                     title={isOpen ? "Collapse Sidebar" : "Expand Sidebar"}
                 >
-                    {isOpen ? <ChevronLeftIcon className="w-6 h-6" /> : <ChevronRightIcon className="w-6 h-6" />}
+                    {isOpen ? <ChevronLeftIcon className="w-6 h-6" aria-hidden="true" /> : <ChevronRightIcon className="w-6 h-6" aria-hidden="true" />}
                 </button>
             </div>
 
@@ -76,7 +76,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
                         !selectedRunId ? 'bg-[var(--accent)] text-[#0D1411] hover:brightness-110' : 'bg-[var(--surface-1)] hover:bg-[var(--surface-active)] text-[var(--text)]'
                     }`}
                 >
-                    <PlusIcon className="w-5 h-5" />
+                    <PlusIcon className="w-5 h-5" aria-hidden="true" />
                     {isOpen && <span>New Run</span>}
                 </button>
             </div>

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -31,20 +31,20 @@ const StatusIndicator: React.FC<{ status: RunStatus }> = ({ status }) => {
     switch (status) {
         case 'IN_PROGRESS':
             return (
-                <div className="w-2.5 h-2.5 rounded-full bg-blue-500 animate-pulse" title="In Progress">
+                <div className="w-2.5 h-2.5 rounded-full bg-[var(--accent-2)] animate-pulse" title="In Progress">
                     <span className="sr-only">In Progress</span>
                 </div>
             );
         case 'COMPLETED':
             return (
                 <div title="Completed">
-                    <CheckCircleIcon className="w-4 h-4 text-green-500" />
+                    <CheckCircleIcon className="w-4 h-4 text-[var(--success)]" />
                 </div>
             );
         case 'FAILED':
             return (
                 <div title="Failed">
-                    <XCircleIcon className="w-4 h-4 text-red-500" />
+                    <XCircleIcon className="w-4 h-4 text-[var(--danger)]" />
                 </div>
             );
         default:
@@ -57,12 +57,12 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
     const [isOpen, setIsOpen] = useState(true);
 
     return (
-        <aside className={`bg-gray-800/50 border-r border-gray-700 flex flex-col transition-all duration-300 ease-in-out ${isOpen ? 'w-64' : 'w-16'}`}>
-            <div className="flex-shrink-0 p-2 flex items-center justify-between border-b border-gray-700">
+        <aside className={`bg-[var(--surface-2)] border-r border-[var(--line)] flex flex-col transition-all duration-300 ease-in-out ${isOpen ? 'w-64' : 'w-16'}`}>
+            <div className="flex-shrink-0 p-2 flex items-center justify-between border-b border-[var(--line)]">
                 {isOpen && <h2 className="text-lg font-semibold ml-2">History</h2>}
                 <button
                     onClick={() => setIsOpen(!isOpen)}
-                    className="p-2 text-gray-400 hover:text-white hover:bg-gray-700/50 rounded-lg transition-colors"
+                    className="p-2 text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--surface-active)] rounded-lg transition-colors"
                     title={isOpen ? "Collapse Sidebar" : "Expand Sidebar"}
                 >
                     {isOpen ? <ChevronLeftIcon className="w-6 h-6" /> : <ChevronRightIcon className="w-6 h-6" />}
@@ -73,7 +73,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
                 <button
                     onClick={onNewRun}
                     className={`w-full flex items-center gap-3 px-3 py-2 text-sm font-semibold rounded-lg transition-colors ${
-                        !selectedRunId ? 'bg-indigo-600 text-white' : 'bg-gray-700 hover:bg-gray-600 text-gray-200'
+                        !selectedRunId ? 'bg-[var(--accent)] text-[#0D1411] hover:brightness-110' : 'bg-[var(--surface-1)] hover:bg-[var(--surface-active)] text-[var(--text)]'
                     }`}
                 >
                     <PlusIcon className="w-5 h-5" />
@@ -88,7 +88,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
                             <button
                                 onClick={() => onNewRun()} // Resets to live view
                                 className={`w-full text-left flex items-center gap-3 p-2 rounded-md transition-colors ${
-                                    !selectedRunId ? 'bg-gray-700' : 'hover:bg-gray-700/50'
+                                    !selectedRunId ? 'bg-[var(--surface-1)]' : 'hover:bg-[var(--surface-active)]'
                                 }`}
                                 title="View current run"
                             >
@@ -97,8 +97,8 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
                                 </div>
                                 {isOpen && (
                                     <div className="overflow-hidden">
-                                        <p className="text-sm font-medium text-gray-300 truncate">Current Run</p>
-                                        <p className="text-xs text-gray-500 capitalize">{currentRunStatus.replace('_', ' ').toLowerCase()}</p>
+                                        <p className="text-sm font-medium text-[var(--text)] truncate">Current Run</p>
+                                        <p className="text-xs text-[var(--text-muted)] capitalize">{currentRunStatus.replace('_', ' ').toLowerCase()}</p>
                                     </div>
                                 )}
                             </button>
@@ -109,7 +109,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
                             <button
                                 onClick={() => onSelectRun(run.id)}
                                 className={`w-full text-left flex items-center gap-3 p-2 rounded-md transition-colors ${
-                                    selectedRunId === run.id ? 'bg-gray-700' : 'hover:bg-gray-700/50'
+                                    selectedRunId === run.id ? 'bg-[var(--surface-1)]' : 'hover:bg-[var(--surface-active)]'
                                 }`}
                                 title={run.prompt}
                             >
@@ -118,8 +118,8 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
                                </div>
                                 {isOpen && (
                                     <div className="overflow-hidden">
-                                        <p className="text-sm font-medium text-gray-300 truncate">{run.prompt || "Image-based prompt"}</p>
-                                        <p className="text-xs text-gray-500">{formatTimestamp(run.timestamp)}</p>
+                                        <p className="text-sm font-medium text-[var(--text)] truncate">{run.prompt || "Image-based prompt"}</p>
+                                        <p className="text-xs text-[var(--text-muted)]">{formatTimestamp(run.timestamp)}</p>
                                     </div>
                                 )}
                             </button>

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -38,13 +38,13 @@ const StatusIndicator: React.FC<{ status: RunStatus }> = ({ status }) => {
         case 'COMPLETED':
             return (
                 <div title="Completed">
-                    <CheckCircleIcon className="w-4 h-4 text-[var(--success)]" />
+                    <CheckCircleIcon className="w-4 h-4 text-[var(--success)]" aria-hidden="true" />
                 </div>
             );
         case 'FAILED':
             return (
                 <div title="Failed">
-                    <XCircleIcon className="w-4 h-4 text-[var(--danger)]" />
+                    <XCircleIcon className="w-4 h-4 text-[var(--danger)]" aria-hidden="true" />
                 </div>
             );
         default:

--- a/components/ImageInput.tsx
+++ b/components/ImageInput.tsx
@@ -1,5 +1,5 @@
 
-import React, { useCallback, useRef, useMemo, useEffect } from 'react';
+import React, { useCallback, useRef, useEffect, useState } from 'react';
 import { UploadIcon, XCircleIcon } from '@/components/icons';
 import { ImageState } from '@/types';
 
@@ -46,15 +46,19 @@ const ImageInput: React.FC<ImageInputProps> = ({ image, onImageChange, disabled 
         fileInputRef.current?.click();
     };
 
-    const previewUrl = useMemo(() => (image ? URL.createObjectURL(image.file) : null), [image]);
+    const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
     useEffect(() => {
+        if (!image) {
+            setPreviewUrl(null);
+            return;
+        }
+        const url = URL.createObjectURL(image.file);
+        setPreviewUrl(url);
         return () => {
-            if (previewUrl) {
-                URL.revokeObjectURL(previewUrl);
-            }
+            URL.revokeObjectURL(url);
         };
-    }, [previewUrl]);
+    }, [image]);
 
     return (
         <div className="mt-4">

--- a/components/ImageInput.tsx
+++ b/components/ImageInput.tsx
@@ -1,5 +1,5 @@
 
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useMemo, useEffect } from 'react';
 import { UploadIcon, XCircleIcon } from '@/components/icons';
 import { ImageState } from '@/types';
 
@@ -46,6 +46,16 @@ const ImageInput: React.FC<ImageInputProps> = ({ image, onImageChange, disabled 
         fileInputRef.current?.click();
     };
 
+    const previewUrl = useMemo(() => (image ? URL.createObjectURL(image.file) : null), [image]);
+
+    useEffect(() => {
+        return () => {
+            if (previewUrl) {
+                URL.revokeObjectURL(previewUrl);
+            }
+        };
+    }, [previewUrl]);
+
     return (
         <div className="mt-4">
             <label className="block text-sm font-medium text-[var(--text)] mb-2">
@@ -53,11 +63,13 @@ const ImageInput: React.FC<ImageInputProps> = ({ image, onImageChange, disabled 
             </label>
             {image ? (
                 <div className="relative group w-full sm:w-64">
-                    <img
-                        src={URL.createObjectURL(image.file)}
-                        alt="Image preview"
-                        className="w-full sm:w-64 h-auto rounded-lg object-cover border-2 border-[var(--line)]"
-                    />
+                    {previewUrl && (
+                        <img
+                            src={previewUrl}
+                            alt="Image preview"
+                            className="w-full sm:w-64 h-auto rounded-lg object-cover border-2 border-[var(--line)]"
+                        />
+                    )}
                     <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 flex items-center justify-center transition-opacity rounded-lg">
                         <button
                             onClick={handleRemoveImage}
@@ -65,7 +77,7 @@ const ImageInput: React.FC<ImageInputProps> = ({ image, onImageChange, disabled 
                             className="p-2 bg-[var(--danger)] bg-opacity-80 text-[var(--text)] rounded-full hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-[var(--danger)] focus:ring-offset-2 focus:ring-offset-[var(--surface-1)] disabled:opacity-50"
                             aria-label="Remove image"
                         >
-                            <XCircleIcon className="w-6 h-6" />
+                            <XCircleIcon className="w-6 h-6" aria-hidden="true" />
                         </button>
                     </div>
                 </div>
@@ -76,7 +88,7 @@ const ImageInput: React.FC<ImageInputProps> = ({ image, onImageChange, disabled 
                     disabled={disabled}
                     className="w-full h-24 p-3 flex flex-col items-center justify-center bg-[var(--surface-1)] border-2 border-dashed border-[var(--line)] rounded-lg hover:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent)] focus:border-[var(--accent)] transition disabled:cursor-not-allowed disabled:opacity-50"
                 >
-                    <UploadIcon className="w-6 h-6 text-[var(--text-muted)] mb-1" />
+                    <UploadIcon className="w-6 h-6 text-[var(--text-muted)] mb-1" aria-hidden="true" />
                     <span className="text-sm text-[var(--text-muted)]">Drag and drop an image, or click to upload</span>
                     <input
                         ref={fileInputRef}

--- a/components/ImageInput.tsx
+++ b/components/ImageInput.tsx
@@ -48,7 +48,7 @@ const ImageInput: React.FC<ImageInputProps> = ({ image, onImageChange, disabled 
 
     return (
         <div className="mt-4">
-            <label className="block text-sm font-medium text-gray-300 mb-2">
+            <label className="block text-sm font-medium text-[var(--text)] mb-2">
                 Image (Optional)
             </label>
             {image ? (
@@ -56,13 +56,13 @@ const ImageInput: React.FC<ImageInputProps> = ({ image, onImageChange, disabled 
                     <img
                         src={URL.createObjectURL(image.file)}
                         alt="Image preview"
-                        className="w-full sm:w-64 h-auto rounded-lg object-cover border-2 border-gray-600"
+                        className="w-full sm:w-64 h-auto rounded-lg object-cover border-2 border-[var(--line)]"
                     />
                     <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 flex items-center justify-center transition-opacity rounded-lg">
                         <button
                             onClick={handleRemoveImage}
                             disabled={disabled}
-                            className="p-2 bg-red-600/80 text-white rounded-full hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:opacity-50"
+                            className="p-2 bg-[var(--danger)] bg-opacity-80 text-[var(--text)] rounded-full hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-[var(--danger)] focus:ring-offset-2 focus:ring-offset-[var(--surface-1)] disabled:opacity-50"
                             aria-label="Remove image"
                         >
                             <XCircleIcon className="w-6 h-6" />
@@ -74,10 +74,10 @@ const ImageInput: React.FC<ImageInputProps> = ({ image, onImageChange, disabled 
                     type="button"
                     onClick={triggerFileInput}
                     disabled={disabled}
-                    className="w-full h-24 p-3 flex flex-col items-center justify-center bg-gray-900 border-2 border-dashed border-gray-600 rounded-lg hover:border-indigo-500 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition disabled:cursor-not-allowed disabled:opacity-50"
+                    className="w-full h-24 p-3 flex flex-col items-center justify-center bg-[var(--surface-1)] border-2 border-dashed border-[var(--line)] rounded-lg hover:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent)] focus:border-[var(--accent)] transition disabled:cursor-not-allowed disabled:opacity-50"
                 >
-                    <UploadIcon className="w-6 h-6 text-gray-400 mb-1" />
-                    <span className="text-sm text-gray-400">Drag and drop an image, or click to upload</span>
+                    <UploadIcon className="w-6 h-6 text-[var(--text-muted)] mb-1" />
+                    <span className="text-sm text-[var(--text-muted)]">Drag and drop an image, or click to upload</span>
                     <input
                         ref={fileInputRef}
                         type="file"

--- a/components/NumericInput.tsx
+++ b/components/NumericInput.tsx
@@ -4,9 +4,10 @@ interface NumericInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
     value: number;
     onCommit: (value: number) => void;
     parser?: (value: string) => number;
+    onCancel?: () => void;
 }
 
-const NumericInput: React.FC<NumericInputProps> = ({ value, onCommit, parser = parseFloat, ...rest }) => {
+const NumericInput: React.FC<NumericInputProps> = ({ value, onCommit, parser = parseFloat, onCancel, ...rest }) => {
     const [inputValue, setInputValue] = React.useState<string>(String(value));
 
     React.useEffect(() => {
@@ -14,11 +15,16 @@ const NumericInput: React.FC<NumericInputProps> = ({ value, onCommit, parser = p
     }, [value]);
 
     const commit = () => {
-        const parsed = parser(inputValue);
+        let parsed = parser(inputValue);
         if (!Number.isNaN(parsed)) {
+            const min = rest.min !== undefined ? Number(rest.min) : undefined;
+            const max = rest.max !== undefined ? Number(rest.max) : undefined;
+            if (min !== undefined) parsed = Math.max(parsed, min);
+            if (max !== undefined) parsed = Math.min(parsed, max);
             onCommit(parsed);
         } else {
             setInputValue(String(value));
+            onCancel?.();
         }
     };
 

--- a/components/NumericInput.tsx
+++ b/components/NumericInput.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+interface NumericInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> {
+    value: number;
+    onCommit: (value: number) => void;
+    parser?: (value: string) => number;
+}
+
+const NumericInput: React.FC<NumericInputProps> = ({ value, onCommit, parser = parseFloat, ...rest }) => {
+    const [inputValue, setInputValue] = React.useState<string>(String(value));
+
+    React.useEffect(() => {
+        setInputValue(String(value));
+    }, [value]);
+
+    const commit = () => {
+        const parsed = parser(inputValue);
+        if (!Number.isNaN(parsed)) {
+            onCommit(parsed);
+        } else {
+            setInputValue(String(value));
+        }
+    };
+
+    return (
+        <input
+            {...rest}
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+            onBlur={commit}
+            onKeyDown={e => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    commit();
+                    (e.target as HTMLInputElement).blur();
+                }
+            }}
+        />
+    );
+};
+
+export default NumericInput;
+

--- a/components/PromptInput.tsx
+++ b/components/PromptInput.tsx
@@ -123,7 +123,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
     }, []);
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
+        if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
             event.preventDefault();
             if (!disabled && !isLoading && (prompt.trim() || images.length > 0)) {
                 onSubmit();

--- a/components/PromptInput.tsx
+++ b/components/PromptInput.tsx
@@ -150,7 +150,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
                                 className="absolute top-1 right-1 p-0.5 bg-black/60 text-[var(--text)] rounded-full hover:bg-[var(--danger)] focus:outline-none focus:ring-2 focus:ring-[var(--danger)] disabled:opacity-50"
                                 aria-label="Remove image"
                             >
-                                <XCircleIcon className="w-5 h-5" />
+                                <XCircleIcon className="w-5 h-5" aria-hidden="true" />
                             </button>
                         </div>
                     ))}
@@ -165,7 +165,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
                         className="p-2 text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--surface-active)] rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         title={images.length >= MAX_IMAGES ? `Maximum ${MAX_IMAGES} images reached` : `Add image (${images.length}/${MAX_IMAGES})`}
                     >
-                         <PlusIcon className="w-5 h-5" />
+                         <PlusIcon className="w-5 h-5" aria-hidden="true" />
                          <span className="sr-only">Add Image</span>
                     </button>
                     <input
@@ -183,7 +183,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
                         className="p-2 text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--surface-active)] rounded-full transition-colors disabled:opacity-50"
                         title="Use microphone (coming soon)"
                     >
-                         <MicrophoneIcon className="w-5 h-5" />
+                         <MicrophoneIcon className="w-5 h-5" aria-hidden="true" />
                          <span className="sr-only">Use microphone</span>
                     </button>
                 </div>
@@ -208,12 +208,12 @@ const PromptInput: React.FC<PromptInputProps> = ({
                 >
                     {isLoading ? (
                         <>
-                            <LoadingSpinner className="w-5 h-5 animate-spin" />
+                            <LoadingSpinner className="w-5 h-5 animate-spin" aria-hidden="true" />
                             Processing...
                         </>
                     ) : (
                         <>
-                           <SparklesIcon className="w-5 h-5" />
+                           <SparklesIcon className="w-5 h-5" aria-hidden="true" />
                            Run 
                         </>
                     )}

--- a/components/PromptInput.tsx
+++ b/components/PromptInput.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useEffect } from 'react';
+import React, { useCallback, useRef, useEffect, useMemo } from 'react';
 import {
     XCircleIcon,
     PlusIcon,
@@ -94,6 +94,16 @@ const PromptInput: React.FC<PromptInputProps> = ({
         fileInputRef.current?.click();
     };
 
+    const imagePreviews = useMemo(() => (
+        images.map(img => ({ ...img, url: URL.createObjectURL(img.file) }))
+    ), [images]);
+
+    useEffect(() => {
+        return () => {
+            imagePreviews.forEach(img => URL.revokeObjectURL(img.url));
+        };
+    }, [imagePreviews]);
+
     const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
             event.preventDefault();
@@ -125,12 +135,12 @@ const PromptInput: React.FC<PromptInputProps> = ({
 
     return (
         <div className="bg-[var(--surface-2)] p-2 rounded-2xl shadow-2xl border border-[var(--line)] flex flex-col gap-2">
-            {images.length > 0 && (
+            {imagePreviews.length > 0 && (
                 <div className="flex flex-wrap gap-2 px-2 pt-1">
-                    {images.map(img => (
+                    {imagePreviews.map(img => (
                         <div key={img.id} className="relative group flex-shrink-0">
                             <img
-                                src={URL.createObjectURL(img.file)}
+                                src={img.url}
                                 alt="Image preview"
                                 className="w-20 h-20 rounded-lg object-cover border border-[var(--line)]"
                             />

--- a/components/PromptInput.tsx
+++ b/components/PromptInput.tsx
@@ -95,7 +95,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
     };
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (event.key === 'Enter' && !event.shiftKey) {
+        if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
             event.preventDefault();
             if (!disabled && !isLoading && (prompt.trim() || images.length > 0)) {
                 onSubmit();

--- a/components/PromptInput.tsx
+++ b/components/PromptInput.tsx
@@ -19,6 +19,7 @@ interface PromptInputProps {
     onSubmit: () => void;
     isLoading?: boolean;
     disabled?: boolean;
+    inputRef?: React.RefObject<HTMLTextAreaElement>;
 }
 
 const readFileAsBase64 = (file: File): Promise<string> => {
@@ -44,10 +45,11 @@ const PromptInput: React.FC<PromptInputProps> = ({
     onImagesChange,
     onSubmit,
     isLoading = false,
-    disabled = false
+    disabled = false,
+    inputRef
 }) => {
     const fileInputRef = useRef<HTMLInputElement>(null);
-    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const textareaRef = inputRef || useRef<HTMLTextAreaElement>(null);
 
     const handleFileChange = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
         const files = event.target.files;
@@ -122,7 +124,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
     const canSubmit = !disabled && (!!prompt.trim() || images.length > 0);
 
     return (
-        <div className="bg-gray-800/50 p-2 rounded-2xl shadow-2xl border border-gray-700 flex flex-col gap-2">
+        <div className="bg-[var(--surface-2)] p-2 rounded-2xl shadow-2xl border border-[var(--line)] flex flex-col gap-2">
             {images.length > 0 && (
                 <div className="flex flex-wrap gap-2 px-2 pt-1">
                     {images.map(img => (
@@ -130,12 +132,12 @@ const PromptInput: React.FC<PromptInputProps> = ({
                             <img
                                 src={URL.createObjectURL(img.file)}
                                 alt="Image preview"
-                                className="w-20 h-20 rounded-lg object-cover border border-gray-600"
+                                className="w-20 h-20 rounded-lg object-cover border border-[var(--line)]"
                             />
                             <button
                                 onClick={() => handleRemoveImage(img.id)}
                                 disabled={disabled || isLoading}
-                                className="absolute top-1 right-1 p-0.5 bg-black/60 text-white rounded-full hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-400 disabled:opacity-50"
+                                className="absolute top-1 right-1 p-0.5 bg-black/60 text-[var(--text)] rounded-full hover:bg-[var(--danger)] focus:outline-none focus:ring-2 focus:ring-[var(--danger)] disabled:opacity-50"
                                 aria-label="Remove image"
                             >
                                 <XCircleIcon className="w-5 h-5" />
@@ -150,7 +152,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
                         type="button"
                         onClick={triggerFileInput}
                         disabled={disabled || isLoading || images.length >= MAX_IMAGES}
-                        className="p-2 text-gray-400 hover:text-white hover:bg-gray-700/50 rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="p-2 text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--surface-active)] rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         title={images.length >= MAX_IMAGES ? `Maximum ${MAX_IMAGES} images reached` : `Add image (${images.length}/${MAX_IMAGES})`}
                     >
                          <PlusIcon className="w-5 h-5" />
@@ -168,7 +170,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
                      <button
                         type="button"
                         disabled
-                        className="p-2 text-gray-400 hover:text-white hover:bg-gray-700/50 rounded-full transition-colors disabled:opacity-50"
+                        className="p-2 text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--surface-active)] rounded-full transition-colors disabled:opacity-50"
                         title="Use microphone (coming soon)"
                     >
                          <MicrophoneIcon className="w-5 h-5" />
@@ -182,7 +184,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
                     onChange={(e) => onPromptChange(e.target.value)}
                     onKeyDown={handleKeyDown}
                     placeholder="Ask me anything, or add up to 5 images..."
-                    className="w-full flex-grow bg-transparent text-gray-200 placeholder-gray-500 text-base resize-none focus:outline-none p-2 min-h-[44px]"
+                    className="w-full flex-grow bg-transparent text-[var(--text)] placeholder-[var(--text-muted)] text-base resize-none focus:outline-none p-2 min-h-[44px]"
                     rows={1}
                     disabled={disabled || isLoading}
                 />
@@ -191,7 +193,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
                     type="button"
                     onClick={onSubmit}
                     disabled={!canSubmit || isLoading}
-                    className="flex-shrink-0 flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-lg shadow-md transition-all duration-300 bg-indigo-600 text-white hover:bg-indigo-500 disabled:bg-gray-600 disabled:cursor-not-allowed"
+                    className="flex-shrink-0 flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-lg shadow-md transition-all duration-300 bg-[var(--accent)] text-[#0D1411] hover:brightness-110 disabled:bg-[var(--surface-1)] disabled:text-[var(--text-muted)] disabled:cursor-not-allowed"
                     title="Run Orchestration"
                 >
                     {isLoading ? (

--- a/components/SegmentedControl.tsx
+++ b/components/SegmentedControl.tsx
@@ -19,7 +19,7 @@ const SegmentedControl = <T extends string>({ options, value, onChange, disabled
     <div
       role="radiogroup"
       aria-label={ariaLabel}
-      className={`flex w-full p-1 bg-gray-900 border border-gray-600 rounded-lg ${disabled ? 'opacity-70 cursor-not-allowed' : ''}`}
+      className={`flex w-full p-1 bg-[var(--surface-1)] border border-[var(--line)] rounded-lg ${disabled ? 'opacity-70 cursor-not-allowed' : ''}`}
     >
       {options.map((option, index) => (
         <button
@@ -30,15 +30,15 @@ const SegmentedControl = <T extends string>({ options, value, onChange, disabled
           aria-checked={value === option.value}
           disabled={disabled}
           title={option.tooltip}
-          className={`relative flex-1 px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 z-10
+          className={`relative flex-1 px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-1)] z-10
             ${index === 0 ? 'rounded-l-md' : ''}
             ${index === options.length - 1 ? 'rounded-r-md' : ''}
-            ${value === option.value ? 'text-white' : 'text-gray-300 hover:bg-gray-700/50'}
+            ${value === option.value ? 'text-[#0D1411]' : 'text-[var(--text)] hover:bg-[var(--surface-active)]'}
             ${disabled ? 'cursor-not-allowed' : ''}
           `}
         >
           {value === option.value && (
-             <span className="absolute inset-0 bg-indigo-600 rounded-md -z-10 motion-safe:transition-transform" />
+             <span className="absolute inset-0 bg-[var(--accent)] rounded-md -z-10 motion-safe:transition-transform" />
           )}
           <span className="relative">{option.label}</span>
         </button>

--- a/components/SegmentedControl.tsx
+++ b/components/SegmentedControl.tsx
@@ -29,6 +29,7 @@ const SegmentedControl = <T extends string>({ options, value, onChange, disabled
           role="radio"
           aria-checked={value === option.value}
           disabled={disabled}
+          aria-disabled={disabled}
           title={option.tooltip}
           className={`relative flex-1 px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-1)] z-10
             ${index === 0 ? 'rounded-l-md' : ''}

--- a/components/SegmentedControl.tsx
+++ b/components/SegmentedControl.tsx
@@ -17,7 +17,7 @@ interface SegmentedControlProps<T extends string> {
 const SegmentedControl = <T extends string>({ options, value, onChange, disabled = false, 'aria-label': ariaLabel }: SegmentedControlProps<T>) => {
   return (
     <div
-      role="radiogroup"
+      role="tablist"
       aria-label={ariaLabel}
       className={`flex w-full p-1 bg-[var(--surface-1)] border border-[var(--line)] rounded-lg ${disabled ? 'opacity-70 cursor-not-allowed' : ''}`}
     >
@@ -26,8 +26,8 @@ const SegmentedControl = <T extends string>({ options, value, onChange, disabled
           key={option.value}
           onClick={() => !disabled && onChange(option.value)}
           type="button"
-          role="radio"
-          aria-checked={value === option.value}
+          role="tab"
+          aria-selected={value === option.value}
           disabled={disabled}
           aria-disabled={disabled}
           title={option.tooltip}

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -354,7 +354,7 @@ const SettingsView: React.FC<SettingsViewProps> = (props) => {
                 {/* --- Main Content --- */}
                 <div className="flex-grow grid md:grid-cols-[240px_1fr] grid-cols-1 min-h-0">
                     {/* Sidebar (Desktop) */}
-                    <aside className="hidden md:block border-r border-[var(--line)] opacity-50 overflow-y-auto">
+                    <aside className="hidden md:block border-r border-[var(--line)]/50 overflow-y-auto">
                         {navigation}
                     </aside>
 

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -85,7 +85,7 @@ const ApiKeySection: React.FC<Pick<SettingsViewProps, 'currentOpenAIApiKey' | 'o
     return (
         <div className="space-y-6">
             <div>
-                <label htmlFor="openai-api-key" className="block text-sm font-medium text-gray-300 mb-2">
+                <label htmlFor="openai-api-key" className="block text-sm font-medium text-[var(--text)] mb-2">
                     OpenAI API Key
                 </label>
                 <div className="flex gap-2">
@@ -95,12 +95,12 @@ const ApiKeySection: React.FC<Pick<SettingsViewProps, 'currentOpenAIApiKey' | 'o
                         value={openAIKey}
                         onChange={(e) => setOpenAIKey(e.target.value)}
                         placeholder="sk-..."
-                        className="flex-grow p-2 bg-gray-900 border border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"
+                        className="flex-grow p-2 bg-[var(--surface-1)] border border-[var(--line)] rounded-lg focus:ring-2 focus:ring-[var(--accent)] focus:border-[var(--accent)] transition"
                     />
                     <button
                         onClick={handleSaveOpenAI}
                         type="button"
-                        className="px-4 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-500 disabled:bg-gray-600 transition-colors"
+                        className="px-4 py-2 bg-[var(--accent)] text-[#0D1411] font-semibold rounded-lg shadow-md hover:brightness-110 disabled:bg-[var(--surface-1)] disabled:text-[var(--text-muted)] transition-colors"
                     >
                         Save
                     </button>
@@ -108,7 +108,7 @@ const ApiKeySection: React.FC<Pick<SettingsViewProps, 'currentOpenAIApiKey' | 'o
             </div>
             
             <div>
-                <label htmlFor="gemini-api-key" className="block text-sm font-medium text-gray-300 mb-2">
+                <label htmlFor="gemini-api-key" className="block text-sm font-medium text-[var(--text)] mb-2">
                     Google Gemini API Key
                 </label>
                 <div className="flex gap-2">
@@ -118,23 +118,23 @@ const ApiKeySection: React.FC<Pick<SettingsViewProps, 'currentOpenAIApiKey' | 'o
                         value={geminiKey}
                         onChange={(e) => setGeminiKey(e.target.value)}
                         placeholder="AIza..."
-                        className="flex-grow p-2 bg-gray-900 border border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"
+                        className="flex-grow p-2 bg-[var(--surface-1)] border border-[var(--line)] rounded-lg focus:ring-2 focus:ring-[var(--accent)] focus:border-[var(--accent)] transition"
                     />
                     <button
                         onClick={handleSaveGemini}
                         type="button"
-                        className="px-4 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-500 disabled:bg-gray-600 transition-colors"
+                        className="px-4 py-2 bg-[var(--accent)] text-[#0D1411] font-semibold rounded-lg shadow-md hover:brightness-110 disabled:bg-[var(--surface-1)] disabled:text-[var(--text-muted)] transition-colors"
                     >
                         Save
                     </button>
                 </div>
-                <p className="text-xs text-gray-500 mt-2">
+                <p className="text-xs text-[var(--text-muted)] mt-2">
                     If left blank, the application will attempt to use the pre-configured environment variable.
                 </p>
             </div>
 
             <div>
-                <label htmlFor="openrouter-api-key" className="block text-sm font-medium text-gray-300 mb-2">
+                <label htmlFor="openrouter-api-key" className="block text-sm font-medium text-[var(--text)] mb-2">
                     OpenRouter API Key
                 </label>
                 <div className="flex gap-2">
@@ -144,12 +144,12 @@ const ApiKeySection: React.FC<Pick<SettingsViewProps, 'currentOpenAIApiKey' | 'o
                         value={openRouterKey}
                         onChange={(e) => setOpenRouterKey(e.target.value)}
                         placeholder="sk-or-..."
-                        className="flex-grow p-2 bg-gray-900 border border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"
+                        className="flex-grow p-2 bg-[var(--surface-1)] border border-[var(--line)] rounded-lg focus:ring-2 focus:ring-[var(--accent)] focus:border-[var(--accent)] transition"
                     />
                     <button
                         onClick={handleSaveOpenRouter}
                         type="button"
-                        className="px-4 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-500 disabled:bg-gray-600 transition-colors"
+                        className="px-4 py-2 bg-[var(--accent)] text-[#0D1411] font-semibold rounded-lg shadow-md hover:brightness-110 disabled:bg-[var(--surface-1)] disabled:text-[var(--text-muted)] transition-colors"
                     >
                         Save
                     </button>
@@ -173,11 +173,11 @@ const SessionSection: React.FC<Pick<SettingsViewProps, 'onSaveSession' | 'onLoad
 
     return (
         <div className="flex flex-col sm:flex-row gap-4">
-            <button onClick={onSaveSession} className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-gray-700/80 text-white font-semibold rounded-lg shadow-md hover:bg-gray-700 transition-colors">
+            <button onClick={onSaveSession} className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-[var(--surface-1)] text-[var(--text)] font-semibold rounded-lg shadow-md hover:bg-[var(--surface-active)] transition-colors">
                 <DownloadIcon className="w-5 h-5" />
                 Save Session
             </button>
-            <button onClick={handleLoadClick} className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-gray-700/80 text-white font-semibold rounded-lg shadow-md hover:bg-gray-700 transition-colors">
+            <button onClick={handleLoadClick} className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-[var(--surface-1)] text-[var(--text)] font-semibold rounded-lg shadow-md hover:bg-[var(--surface-active)] transition-colors">
                 <UploadIcon className="w-5 h-5" />
                 Load Session
             </button>
@@ -200,7 +200,7 @@ const HistorySection: React.FC<Pick<SettingsViewProps, 'queryHistory' | 'onSelec
     };
     
     if (queryHistory.length === 0) {
-        return <p className="text-gray-500 italic">Your query history is empty.</p>;
+        return <p className="text-[var(--text-muted)] italic">Your query history is empty.</p>;
     }
 
     return (
@@ -209,7 +209,7 @@ const HistorySection: React.FC<Pick<SettingsViewProps, 'queryHistory' | 'onSelec
                 <li key={index}>
                     <button 
                         onClick={() => handleQueryClick(query)}
-                        className="w-full text-left p-2.5 text-sm text-indigo-300 bg-gray-900/50 rounded-md hover:bg-gray-700 transition-colors truncate"
+                        className="w-full text-left p-2.5 text-sm text-[var(--accent-2)] bg-[var(--surface-2)] rounded-md hover:bg-[var(--surface-active)] transition-colors truncate"
                         title={query}
                     >
                         {query}
@@ -273,7 +273,7 @@ const SettingsView: React.FC<SettingsViewProps> = (props) => {
                         key={section.id}
                         onClick={() => handleSectionSelect(section.id)}
                         className={`w-full flex items-center gap-3 text-left px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
-                            isActive ? 'bg-indigo-600 text-white' : 'text-gray-300 hover:bg-gray-700/50 hover:text-white'
+                            isActive ? 'bg-[var(--accent)] text-[#0D1411]' : 'text-[var(--text)] hover:bg-[var(--surface-active)]'
                         }`}
                         aria-current={isActive ? 'page' : undefined}
                     >
@@ -286,7 +286,7 @@ const SettingsView: React.FC<SettingsViewProps> = (props) => {
     );
 
     return (
-        <div 
+        <div
             className="fixed inset-0 bg-black/60 backdrop-blur-sm flex justify-center items-center z-50 animate-fade-in-up p-4"
             style={{ animationDuration: '0.3s'}}
             onClick={onClose}
@@ -294,22 +294,22 @@ const SettingsView: React.FC<SettingsViewProps> = (props) => {
             aria-modal="true"
             aria-labelledby="settings-title"
         >
-            <div 
-                className="bg-gray-800 rounded-xl shadow-2xl border border-gray-700 w-full max-w-4xl h-full max-h-[700px] flex flex-col"
+            <div
+                className="bg-[var(--surface-2)] rounded-xl shadow-2xl border border-[var(--line)] w-full max-w-4xl h-full max-h-[700px] flex flex-col"
                 onClick={e => e.stopPropagation()}
             >
                 {/* --- Header --- */}
-                <header className="flex items-center justify-between p-4 border-b border-gray-700 flex-shrink-0">
+                <header className="flex items-center justify-between p-4 border-b border-[var(--line)] flex-shrink-0">
                     <div className="flex items-center gap-3">
-                         <button onClick={handleMobileBack} className="p-1 rounded-full text-gray-400 hover:bg-gray-700 md:hidden" aria-label="Back to settings sections" style={{ visibility: mobileDrillIn ? 'visible': 'hidden' }}>
+                         <button onClick={handleMobileBack} className="p-1 rounded-full text-[var(--text-muted)] hover:bg-[var(--surface-active)] md:hidden" aria-label="Back to settings sections" style={{ visibility: mobileDrillIn ? 'visible': 'hidden' }}>
                             <ChevronLeftIcon className="w-6 h-6" />
                         </button>
-                        <h2 id="settings-title" className="text-lg font-bold text-gray-100">
+                        <h2 id="settings-title" className="text-lg font-bold text-[var(--text)]">
                              <span className="md:hidden">{mobileDrillIn ? activeSection.label : "Settings"}</span>
                              <span className="hidden md:inline">Settings</span>
                         </h2>
                     </div>
-                     <button onClick={onClose} type="button" className="p-1 rounded-full text-gray-400 hover:bg-gray-700 hover:text-white" aria-label="Close settings">
+                     <button onClick={onClose} type="button" className="p-1 rounded-full text-[var(--text-muted)] hover:bg-[var(--surface-active)] hover:text-[var(--text)]" aria-label="Close settings">
                         <XMarkIcon className="w-6 h-6" />
                     </button>
                 </header>
@@ -317,7 +317,7 @@ const SettingsView: React.FC<SettingsViewProps> = (props) => {
                 {/* --- Main Content --- */}
                 <div className="flex-grow grid md:grid-cols-[240px_1fr] grid-cols-1 min-h-0">
                     {/* Sidebar (Desktop) */}
-                    <aside className="hidden md:block border-r border-gray-700/50 overflow-y-auto">
+                    <aside className="hidden md:block border-r border-[var(--line)] opacity-50 overflow-y-auto">
                         {navigation}
                     </aside>
 
@@ -327,8 +327,8 @@ const SettingsView: React.FC<SettingsViewProps> = (props) => {
                         <div className="md:hidden">
                             {mobileDrillIn ? (
                                 <div className="p-6 space-y-4">
-                                    <p className="text-gray-400 text-sm">{activeSection.description}</p>
-                                    <div className="border-t border-gray-700 pt-4">{renderSectionContent(activeSectionId)}</div>
+                                    <p className="text-[var(--text-muted)] text-sm">{activeSection.description}</p>
+                                    <div className="border-t border-[var(--line)] pt-4">{renderSectionContent(activeSectionId)}</div>
                                 </div>
                             ) : (
                                 navigation
@@ -337,9 +337,9 @@ const SettingsView: React.FC<SettingsViewProps> = (props) => {
 
                         {/* Desktop View */}
                         <div className="hidden md:block p-6 space-y-4">
-                             <h3 className="text-xl font-semibold text-gray-200">{activeSection.label}</h3>
-                             <p className="text-gray-400 text-sm">{activeSection.description}</p>
-                             <div className="border-t border-gray-700 pt-4">{renderSectionContent(activeSectionId)}</div>
+                             <h3 className="text-xl font-semibold text-[var(--text)]">{activeSection.label}</h3>
+                             <p className="text-[var(--text-muted)] text-sm">{activeSection.description}</p>
+                             <div className="border-t border-[var(--line)] pt-4">{renderSectionContent(activeSectionId)}</div>
                         </div>
                     </main>
                 </div>

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -261,7 +261,7 @@ const SettingsView: React.FC<SettingsViewProps> = (props) => {
                 dialogRef.current.querySelectorAll<HTMLElement>(
                     'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
                 )
-            ).filter(el => !el.hasAttribute('disabled'));
+            ).filter(el => !el.hasAttribute('disabled') && el.offsetParent !== null);
             if (focusables.length === 0) return;
             const first = focusables[0];
             const last = focusables[focusables.length - 1];

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -174,11 +174,11 @@ const SessionSection: React.FC<Pick<SettingsViewProps, 'onSaveSession' | 'onLoad
     return (
         <div className="flex flex-col sm:flex-row gap-4">
             <button onClick={onSaveSession} className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-[var(--surface-1)] text-[var(--text)] font-semibold rounded-lg shadow-md hover:bg-[var(--surface-active)] transition-colors">
-                <DownloadIcon className="w-5 h-5" />
+                <DownloadIcon className="w-5 h-5" aria-hidden="true" />
                 Save Session
             </button>
             <button onClick={handleLoadClick} className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-[var(--surface-1)] text-[var(--text)] font-semibold rounded-lg shadow-md hover:bg-[var(--surface-active)] transition-colors">
-                <UploadIcon className="w-5 h-5" />
+                <UploadIcon className="w-5 h-5" aria-hidden="true" />
                 Load Session
             </button>
             <input

--- a/constants.ts
+++ b/constants.ts
@@ -18,8 +18,9 @@ export const GEMINI_PRO_MODEL = "gemini-2.5-pro";
 
 // OpenAI Models
 export const OPENAI_AGENT_MODEL = "gpt-5";
+export const OPENAI_GPT5_MINI_MODEL = "gpt-5-mini";
 export const OPENAI_ARBITER_MODEL = "gpt-5";
-export const OPENAI_JUDGE_MODEL = "gpt-5-mini"; // For DeepConf judge, as per request.
+export const OPENAI_JUDGE_MODEL = OPENAI_GPT5_MINI_MODEL; // For DeepConf judge and mini agents.
 
 // OpenRouter Models - Using popular models as examples
 export const OPENROUTER_GPT_4O = "openai/gpt-4o";

--- a/index.html
+++ b/index.html
@@ -26,6 +26,27 @@
     </script>
     <script src="https://cdn.tailwindcss.com" defer></script>
     <style>
+      :root {
+        --bg: #071D10;
+        --surface-1: #0A2A16;
+        --surface-2: #0D361D;
+        --surface-active: #104224;
+        --primary: #14532D;
+
+        --text: #E8EEEA;
+        --text-muted: #ADC3B6;
+        --line: #123722;
+
+        --accent: #C6A15B;
+        --accent-2: #2FA899;
+        --danger: #B2513B;
+        --warn: #D7A152;
+        --success: #7FBF8A;
+      }
+      body {
+        background-color: var(--bg);
+        color: var(--text);
+      }
       /* For custom scrollbars to match the dark theme */
       html {
         scrollbar-color: #4b5563 #1f2937; /* thumb and track color for Firefox */
@@ -138,7 +159,7 @@
 }
 </script>
 </head>
-  <body class="text-gray-200">
+  <body class="bg-[var(--bg)] text-[var(--text)]">
     <div id="background-effects"></div>
     <div id="root"></div>
     <script type="module" src="./index.tsx"></script>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     <script src="https://cdn.tailwindcss.com" defer></script>
     <style>
       :root {
+        color-scheme: dark;
         --bg: #071D10;
         --surface-1: #0A2A16;
         --surface-2: #0D361D;

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -4,7 +4,7 @@ export const EXPERT_COLORS = [
   'var(--success)',
   'var(--warn)',
   'var(--danger)'
-];
+] as const;
 
 /**
  * Returns a CSS color value for a given expert index (1-based).

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -1,0 +1,16 @@
+export const EXPERT_COLORS = [
+  'var(--accent)',
+  'var(--accent-2)',
+  'var(--success)',
+  'var(--warn)',
+  'var(--danger)'
+];
+
+/**
+ * Returns a CSS color value for a given expert index (1-based).
+ * Colors cycle through the EXPERT_COLORS array when index exceeds its length.
+ */
+export function getExpertColor(index: number): string {
+  if (index <= 0) return EXPERT_COLORS[0];
+  return EXPERT_COLORS[(index - 1) % EXPERT_COLORS.length];
+}

--- a/moe/arbiter.ts
+++ b/moe/arbiter.ts
@@ -167,6 +167,6 @@ export const arbitrateStream = async (
         }
         return transformGeminiStream();
     } catch (error) {
-        handleGeminiError(error, 'arbiter', 'arbitration');
+        return handleGeminiError(error, 'arbiter', 'arbitration');
     }
 };

--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -77,7 +77,7 @@ const runExpertGeminiSingle = async (
         const response = await callWithGeminiRetry(() => geminiAI.models.generateContent(generateContentParams));
         return getGeminiResponseText(response);
     } catch (error) {
-        handleGeminiError(error, 'dispatcher', 'dispatch');
+        return handleGeminiError(error, 'dispatcher', 'dispatch');
     }
 }
 

--- a/types.ts
+++ b/types.ts
@@ -2,6 +2,7 @@ import {
     GEMINI_FLASH_MODEL,
     GEMINI_PRO_MODEL,
     OPENAI_AGENT_MODEL,
+    OPENAI_GPT5_MINI_MODEL,
     OPENAI_ARBITER_GPT5_MEDIUM_REASONING,
     OPENAI_ARBITER_GPT5_HIGH_REASONING
 } from './constants';
@@ -34,7 +35,7 @@ export interface ImageState {
 
 // New types for direct manipulation UI
 export type GeminiModel = typeof GEMINI_FLASH_MODEL | typeof GEMINI_PRO_MODEL;
-export type OpenAIModel = typeof OPENAI_AGENT_MODEL;
+export type OpenAIModel = typeof OPENAI_AGENT_MODEL | typeof OPENAI_GPT5_MINI_MODEL;
 export type OpenRouterModel = string; // e.g., "openai/gpt-4o"
 export type AgentModel = GeminiModel | OpenAIModel | OpenRouterModel;
 


### PR DESCRIPTION
## Summary
- expose OpenAI gpt-5-mini alongside gpt-5 and wire constant into types
- allow selecting gpt-5-mini in AgentConfig UI
- add global keyboard shortcuts for running, adding experts, focusing prompt, and toggling agent lanes
- introduce dark theme color tokens and apply them across UI for high-contrast palette

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad2af886508322890e438b220bdbf8