### PR TITLE
Simplify numeric input handling and fix TypeScript errors

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -464,7 +464,6 @@ const App: React.FC = () => {
     }, []);
 
     const latestHandleRun = useRef(handleRun);
-    const agentsRef = useRef(agents);
     const isHistoryViewRef = useRef(false);
 
     useEffect(() => {

--- a/components/AgentConfigCard.tsx
+++ b/components/AgentConfigCard.tsx
@@ -14,8 +14,6 @@ interface AgentConfigCardProps {
   displayId: number;
 }
 
-const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
-
 const getStatusIndicator = (status: AgentStatus): React.ReactNode => {
     switch (status) {
         case 'RUNNING':
@@ -201,7 +199,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 type="number"
                                 id={`traces-${config.id}`}
                                 value={config.settings.traceCount}
-                                onCommit={(value) => handleSettingChange({ traceCount: clamp(value, 2, 32) })}
+                                onCommit={(value) => handleSettingChange({ traceCount: value })}
                                 parser={(v) => parseInt(v, 10)}
                                 disabled={disabled}
                                 min="2" max="32" step="1"
@@ -241,7 +239,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 type="number"
                                 id={`tau-${config.id}`}
                                 value={config.settings.tau}
-                                onCommit={(value) => handleSettingChange({ tau: clamp(value, 0.5, 1.0) })}
+                                onCommit={(value) => handleSettingChange({ tau: value })}
                                 parser={(v) => parseFloat(v)}
                                 disabled={disabled}
                                 min="0.5" max="1.0" step="0.01"
@@ -255,7 +253,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                                 type="number"
                                 id={`groupWindow-${config.id}`}
                                 value={config.settings.groupWindow}
-                                onCommit={(value) => handleSettingChange({ groupWindow: clamp(value, 8, 4096) })}
+                                onCommit={(value) => handleSettingChange({ groupWindow: value })}
                                 parser={(v) => parseInt(v, 10)}
                                 disabled={disabled}
                                 min="8" max="4096" step="8"
@@ -321,19 +319,19 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                      <div className="col-span-2 grid grid-cols-2 gap-3">
                         <div>
                          <label htmlFor={`or-temp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Temperature</label>
-                             <NumericInput type="number" id={`or-temp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).temperature} onCommit={(value) => handleSettingChange({ temperature: clamp(value, 0, 2) })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-temp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).temperature} onCommit={(value) => handleSettingChange({ temperature: value })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                         <div>
                              <label htmlFor={`or-topk-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Top K</label>
-                             <NumericInput type="number" id={`or-topk-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topK} onCommit={(value) => handleSettingChange({ topK: Math.max(1, value) })} parser={(v) => parseInt(v, 10)} disabled={disabled} min="1" step="1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-topk-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topK} onCommit={(value) => handleSettingChange({ topK: value })} parser={(v) => parseInt(v, 10)} disabled={disabled} min="1" step="1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                          <div>
                              <label htmlFor={`or-topp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Top P</label>
-                             <NumericInput type="number" id={`or-topp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topP} onCommit={(value) => handleSettingChange({ topP: clamp(value, 0, 1) })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="1" step="0.05" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-topp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).topP} onCommit={(value) => handleSettingChange({ topP: value })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="1" step="0.05" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                          <div>
                              <label htmlFor={`or-repp-${config.id}`} className="block text-sm font-medium text-[var(--text-muted)] mb-1">Repetition Penalty</label>
-                             <NumericInput type="number" id={`or-repp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).repetitionPenalty} onCommit={(value) => handleSettingChange({ repetitionPenalty: clamp(value, 0, 2) })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
+                             <NumericInput type="number" id={`or-repp-${config.id}`} value={(config.settings as OpenRouterAgentSettings).repetitionPenalty} onCommit={(value) => handleSettingChange({ repetitionPenalty: value })} parser={(v) => parseFloat(v)} disabled={disabled} min="0" max="2" step="0.1" className="w-full p-1.5 text-sm bg-[var(--surface-1)] border border-[var(--line)] rounded-md focus:ring-2 focus:ring-[var(--accent)]"/>
                         </div>
                     </div>
                 )}

--- a/components/AgentEnsemble.tsx
+++ b/components/AgentEnsemble.tsx
@@ -100,7 +100,7 @@ const AgentEnsemble = forwardRef<AgentEnsembleHandles, AgentEnsembleProps>(({ ag
             />
         </div>
     );
-};
+});
 
 AgentEnsemble.displayName = 'AgentEnsemble';
 

--- a/components/PromptInput.tsx
+++ b/components/PromptInput.tsx
@@ -123,7 +123,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
     }, []);
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
+        if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
             event.preventDefault();
             if (!disabled && !isLoading && (prompt.trim() || images.length > 0)) {
                 onSubmit();

--- a/moe/arbiter.ts
+++ b/moe/arbiter.ts
@@ -168,5 +168,6 @@ export const arbitrateStream = async (
         return transformGeminiStream();
     } catch (error) {
         handleGeminiError(error, 'arbiter', 'arbitration');
+        throw error;
     }
 };

--- a/moe/arbiter.ts
+++ b/moe/arbiter.ts
@@ -167,7 +167,6 @@ export const arbitrateStream = async (
         }
         return transformGeminiStream();
     } catch (error) {
-        handleGeminiError(error, 'arbiter', 'arbitration');
-        throw error;
+        return handleGeminiError(error, 'arbiter', 'arbitration');
     }
 };

--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -77,8 +77,7 @@ const runExpertGeminiSingle = async (
         const response = await callWithGeminiRetry(() => geminiAI.models.generateContent(generateContentParams));
         return getGeminiResponseText(response);
     } catch (error) {
-        handleGeminiError(error, 'dispatcher', 'dispatch');
-        throw error;
+        return handleGeminiError(error, 'dispatcher', 'dispatch');
     }
 }
 

--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -78,6 +78,7 @@ const runExpertGeminiSingle = async (
         return getGeminiResponseText(response);
     } catch (error) {
         handleGeminiError(error, 'dispatcher', 'dispatch');
+        throw error;
     }
 }
 


### PR DESCRIPTION
## Summary
- Rely on `NumericInput` for range clamping and close the `forwardRef` wrapper correctly
- Drop duplicate `agentsRef` and guard prompt submission against IME composition
- Propagate dispatcher/arbiter errors so TypeScript knows all paths return

## Testing
- `npm test -- --run`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68ae7ef651b88322a52fc138bd790321