### PR TITLE
Add retry/backoff and refresh arbiter models

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,11 +17,12 @@ import {
     GeminiThinkingEffort,
     RunStatus
 } from '@/types';
-import { 
-    GEMINI_PRO_MODEL, 
+import {
+    GEMINI_PRO_MODEL,
     OPENAI_ARBITER_GPT5_MEDIUM_REASONING,
     OPENAI_ARBITER_GPT5_HIGH_REASONING,
     GEMINI_FLASH_MODEL,
+    OPENAI_GPT5_MINI_MODEL,
     OPENAI_AGENT_MODEL,
     OPENROUTER_GPT_4O,
     OPENROUTER_CLAUDE_3_HAIKU,
@@ -947,10 +948,11 @@ const ArbiterSettings: React.FC<{
     isLoading: boolean;
 }> = ({ arbiterModel, setArbiterModel, openAIArbiterVerbosity, setOpenAIArbiterVerbosity, geminiArbiterEffort, setGeminiArbiterEffort, isLoading }) => {
     const arbiterModelOptions: { label: string; value: ArbiterModel; provider: 'gemini' | 'openai' | 'openrouter'; tooltip: string }[] = [
+        { label: 'Gemini 2.5 Flash', value: GEMINI_FLASH_MODEL, provider: 'gemini', tooltip: 'Google\'s fast and cost-effective model for general arbitration.' },
         { label: 'Gemini 2.5 Pro', value: GEMINI_PRO_MODEL, provider: 'gemini', tooltip: 'Google\'s most capable model, with a large context window and strong reasoning. Recommended for complex synthesis.' },
+        { label: 'GPT-5 Mini', value: OPENAI_GPT5_MINI_MODEL, provider: 'openai', tooltip: 'OpenAI\'s lightweight GPT-5 model for quick arbitration with lower latency.' },
         { label: 'GPT-5 (Med)', value: OPENAI_ARBITER_GPT5_MEDIUM_REASONING, provider: 'openai', tooltip: 'OpenAI\'s powerful GPT-5 model with standard reasoning. A strong, balanced choice for arbitration.' },
         { label: 'GPT-5 (High)', value: OPENAI_ARBITER_GPT5_HIGH_REASONING, provider: 'openai', tooltip: 'GPT-5 with enhanced, step-by-step reasoning. May produce higher quality synthesis for nuanced topics at a higher latency.' },
-        { label: 'OR GPT-4o', value: OPENROUTER_GPT_4O, provider: 'openrouter', tooltip: 'GPT-4o via OpenRouter. Excellent general-purpose model with strong vision capabilities.' },
         { label: 'OR Claude Haiku', value: OPENROUTER_CLAUDE_3_HAIKU, provider: 'openrouter', tooltip: 'Anthropic\'s fastest model via OpenRouter. Ideal for quick, responsive arbitration.' },
     ];
     const openAIVerbosityOptions: { label: string; value: OpenAIVerbosity }[] = [
@@ -963,6 +965,7 @@ const ArbiterSettings: React.FC<{
         { label: 'High', value: 'high' },
         { label: 'Medium', value: 'medium' },
         { label: 'Low', value: 'low' },
+        { label: 'None', value: 'none' },
     ];
     
     const selectedModelOption = arbiterModelOptions.find(opt => opt.value === arbiterModel);

--- a/moe/arbiter.ts
+++ b/moe/arbiter.ts
@@ -1,13 +1,16 @@
 import OpenAI from 'openai';
 import { Draft } from './types';
-import { getGeminiClient, getOpenAIClient, getOpenRouterApiKey } from '@/services/llmService';
+import { getGeminiClient, getOpenAIClient, getOpenRouterApiKey, fetchWithRetry, callWithRetry } from '@/services/llmService';
 import { getAppUrl, getGeminiResponseText } from '@/lib/utils';
 import {
     ARBITER_PERSONA,
     ARBITER_HIGH_REASONING_PROMPT_MODIFIER,
     OPENAI_ARBITER_GPT5_HIGH_REASONING,
+    OPENAI_ARBITER_GPT5_MEDIUM_REASONING,
     GEMINI_PRO_MODEL,
+    GEMINI_FLASH_MODEL,
     OPENAI_ARBITER_MODEL,
+    OPENAI_REASONING_PROMPT_PREFIX,
 } from '@/constants';
 import { GeminiThinkingEffort } from '@/types';
 import { callWithGeminiRetry, handleGeminiError } from '@/services/geminiUtils';
@@ -16,6 +19,14 @@ const GEMINI_PRO_BUDGETS: Record<Extract<GeminiThinkingEffort, 'low' | 'medium' 
     low: 8192,
     medium: 24576,
     high: 32768,
+    dynamic: -1,
+};
+
+const GEMINI_FLASH_BUDGETS: Record<GeminiThinkingEffort, number> = {
+    none: 0,
+    low: 4096,
+    medium: 12288,
+    high: 24576,
     dynamic: -1,
 };
 
@@ -88,70 +99,85 @@ export const arbitrateStream = async (
         ];
         const body = { model: arbiterModel, messages, stream: true };
 
-        const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
-            method: 'POST',
-            headers,
-            body: JSON.stringify(body),
-        });
+        try {
+            const response = await fetchWithRetry(
+                'https://openrouter.ai/api/v1/chat/completions',
+                {
+                    method: 'POST',
+                    headers,
+                    body: JSON.stringify(body),
+                },
+                'OpenRouter'
+            );
 
-        if (!response.ok || !response.body) {
-            const errorData = await response.json().catch(() => ({}));
-            throw new Error(`OpenRouter API Error: ${errorData.error?.message || response.statusText}`);
+            if (!response.ok || !response.body) {
+                const errorData = await response.json().catch(() => ({}));
+                throw new Error(`OpenRouter API Error: ${errorData.error?.message || response.statusText}`);
+            }
+
+            return openRouterStreamer(response.body);
+        } catch (error) {
+            if (error instanceof Error) {
+                throw error;
+            }
+            throw new Error('OpenRouter request failed.');
         }
-        
-        return openRouterStreamer(response.body);
     }
-    
+
     // OpenAI Logic
     if (arbiterModel.startsWith('gpt-')) {
         const openaiAI = getOpenAIClient();
-        let systemPersona = arbiterModel === OPENAI_ARBITER_GPT5_HIGH_REASONING
-            ? ARBITER_PERSONA + ARBITER_HIGH_REASONING_PROMPT_MODIFIER
-            : ARBITER_PERSONA;
-        
+
+        let systemPersona = ARBITER_PERSONA;
+        if (arbiterModel === OPENAI_ARBITER_GPT5_HIGH_REASONING) {
+            systemPersona = OPENAI_REASONING_PROMPT_PREFIX + systemPersona + ARBITER_HIGH_REASONING_PROMPT_MODIFIER;
+        }
         systemPersona += `\nYour final synthesized response should have a verbosity level of: ${arbiterVerbosity}.`;
 
-        const inputPrompt = `${systemPersona}\n\n${arbiterPrompt}`;
-        const effort = arbiterModel === OPENAI_ARBITER_GPT5_HIGH_REASONING ? 'high' : 'medium';
+        const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+            { role: 'system', content: systemPersona },
+            { role: 'user', content: arbiterPrompt },
+        ];
+
+        const model = (arbiterModel === OPENAI_ARBITER_GPT5_MEDIUM_REASONING || arbiterModel === OPENAI_ARBITER_GPT5_HIGH_REASONING)
+            ? OPENAI_ARBITER_MODEL
+            : arbiterModel;
 
         try {
-            const stream = await openaiAI.responses.create({
-                model: OPENAI_ARBITER_MODEL,
-                input: inputPrompt,
-                reasoning: { effort },
-                stream: true,
-            });
+            const stream = await callWithRetry(
+                () => openaiAI.chat.completions.create({ model, messages, stream: true }),
+                'OpenAI'
+            );
 
             async function* transformStream(): AsyncGenerator<{ text: string }> {
                 for await (const chunk of stream) {
-                    if (chunk.type === 'response.output_text.delta') {
-                        yield { text: chunk.delta };
+                    const text = chunk.choices[0]?.delta?.content;
+                    if (text) {
+                        yield { text };
                     }
                 }
             }
             return transformStream();
-
         } catch (error) {
             console.error("Error calling the OpenAI API for arbiter:", error);
-            if (error instanceof OpenAI.APIError) {
-                 throw new Error(error.message);
-            }
             if (error instanceof Error) {
-                throw new Error(`An error occurred with the OpenAI Arbiter: ${error.message}`);
+                throw error;
             }
-            throw new Error(`An unknown error occurred while communicating with the OpenAI model for arbitration.`);
+            throw new Error('An unknown error occurred while communicating with the OpenAI model for arbitration.');
         }
     }
-    
+
     // Gemini Logic for the arbiter.
-    const effortForPro = geminiArbiterEffort === 'none' ? 'dynamic' : geminiArbiterEffort;
-    const budget = GEMINI_PRO_BUDGETS[effortForPro];
+    const model = arbiterModel === GEMINI_FLASH_MODEL ? GEMINI_FLASH_MODEL : GEMINI_PRO_MODEL;
+    const budgets = model === GEMINI_FLASH_MODEL ? GEMINI_FLASH_BUDGETS : GEMINI_PRO_BUDGETS;
+    const effortKey = model === GEMINI_PRO_MODEL && geminiArbiterEffort === 'none' ? 'dynamic' : geminiArbiterEffort;
+    const budget = budgets[effortKey];
 
     const geminiAI = getGeminiClient();
     try {
         const stream = await callWithGeminiRetry(() =>
             geminiAI.models.generateContentStream({
-                model: GEMINI_PRO_MODEL, // Arbiter always uses the Pro model for Gemini
+                model,
                 contents: { parts: [{ text: arbiterPrompt }] },
                 config: {
                     systemInstruction: ARBITER_PERSONA,

--- a/services/llmService.ts
+++ b/services/llmService.ts
@@ -3,6 +3,60 @@
 import { GoogleGenAI } from "@google/genai";
 import OpenAI from "openai";
 
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export const fetchWithRetry = async (
+    input: RequestInfo,
+    init: RequestInit,
+    serviceName: string,
+    retries = 3,
+    baseDelayMs = 500,
+): Promise<Response> => {
+    for (let attempt = 0; ; attempt++) {
+        try {
+            const response = await fetch(input, init);
+            if (response.status >= 500 && response.status < 600) {
+                if (attempt < retries) {
+                    await sleep(baseDelayMs * Math.pow(2, attempt));
+                    continue;
+                }
+                throw new Error(`${serviceName} service is temporarily unavailable. Please try again later.`);
+            }
+            return response;
+        } catch (error) {
+            if (attempt < retries) {
+                await sleep(baseDelayMs * Math.pow(2, attempt));
+            } else {
+                throw new Error(`${serviceName} service is temporarily unavailable. Please try again later.`);
+            }
+        }
+    }
+};
+
+export const callWithRetry = async <T>(
+    fn: () => Promise<T>,
+    serviceName: string,
+    retries = 3,
+    baseDelayMs = 500,
+): Promise<T> => {
+    for (let attempt = 0; ; attempt++) {
+        try {
+            return await fn();
+        } catch (error) {
+            const maybeError = error as { status?: number; response?: { status?: number } };
+            const status = maybeError.status ?? maybeError.response?.status;
+            if (status && status >= 500 && status < 600 && attempt < retries) {
+                await sleep(baseDelayMs * Math.pow(2, attempt));
+                continue;
+            }
+            if (status && status >= 500 && status < 600) {
+                throw new Error(`${serviceName} service is temporarily unavailable. Please try again later.`);
+            }
+            throw error;
+        }
+    }
+};
+
 let geminiClient: GoogleGenAI | undefined;
 let currentGeminiApiKey: string | undefined;
 

--- a/types.ts
+++ b/types.ts
@@ -103,7 +103,13 @@ export interface OpenRouterAgentConfig extends BaseAgentConfig {
 export type AgentConfig = GeminiAgentConfig | OpenAIAgentConfig | OpenRouterAgentConfig;
 
 // Types for session management
-export type ArbiterModel = typeof GEMINI_PRO_MODEL | typeof OPENAI_ARBITER_GPT5_MEDIUM_REASONING | typeof OPENAI_ARBITER_GPT5_HIGH_REASONING | string;
+export type ArbiterModel =
+    | typeof GEMINI_PRO_MODEL
+    | typeof GEMINI_FLASH_MODEL
+    | typeof OPENAI_GPT5_MINI_MODEL
+    | typeof OPENAI_ARBITER_GPT5_MEDIUM_REASONING
+    | typeof OPENAI_ARBITER_GPT5_HIGH_REASONING
+    | string;
 export type OpenAIVerbosity = 'low' | 'medium' | 'high';
 
 export interface SavedAgentConfig {


### PR DESCRIPTION
## Summary
- add reusable retry helpers for API requests and surface outage messaging
- support Gemini 2.5 Flash, GPT-5 Mini, and cleaned OpenRouter options for arbiter
- switch arbiter to OpenAI chat completions with standard model naming

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae8c254d188322b492f46311c1862b