### PR TITLE
Add retry/backoff and refresh arbiter models

### DIFF
--- a/services/llmService.ts
+++ b/services/llmService.ts
@@ -29,6 +29,8 @@ export const fetchWithRetry = async (
         }
         await sleep(baseDelayMs * Math.pow(2, attempt));
     }
+    // This path should be unreachable, but ensures type safety if the loop completes without returning.
+    throw new Error("fetchWithRetry exhausted all retries without success.");
 };
 
 export const callWithRetry = async <T>(
@@ -57,6 +59,8 @@ export const callWithRetry = async <T>(
         }
         await sleep(baseDelayMs * Math.pow(2, attempt));
     }
+    // This path should be unreachable, but ensures type safety if the loop completes without returning.
+    throw new Error("callWithRetry exhausted all retries without success.");
 };
 
 let geminiClient: GoogleGenAI | undefined;


### PR DESCRIPTION
## Summary
- add fallback throw if `fetchWithRetry` loop completes without returning
- add unreachable safety throw to `callWithRetry`

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68afb0da26408322807d17528d1e0023