### PR TITLE
Add retry/backoff and refresh arbiter models

### DIFF
--- a/services/llmService.ts
+++ b/services/llmService.ts
@@ -29,6 +29,7 @@ export const fetchWithRetry = async (
         }
         await sleep(baseDelayMs * Math.pow(2, attempt));
     }
+    throw new Error("fetchWithRetry exhausted all retries without success.");
 };
 
 export const callWithRetry = async <T>(
@@ -57,6 +58,7 @@ export const callWithRetry = async <T>(
         }
         await sleep(baseDelayMs * Math.pow(2, attempt));
     }
+    throw new Error("callWithRetry exhausted all retries without success.");
 };
 
 let geminiClient: GoogleGenAI | undefined;


### PR DESCRIPTION
## Summary
- add reusable retry helpers for API requests and surface outage messaging
- support Gemini 2.5 Flash, GPT-5 Mini, and cleaned OpenRouter options for arbiter
- switch arbiter to OpenAI chat completions with standard model naming
- ensure retry helpers throw when all attempts are exhausted

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68afb088ddb883229b1b6cc2d3d77aaa