### PR TITLE
Fix mobile history drawer focus handling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -215,11 +215,27 @@ const App: React.FC = () => {
     const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
     const [isMobileHistoryOpen, setMobileHistoryOpen] = useState(false);
     const openHistoryButtonRef = useRef<HTMLButtonElement | null>(null);
+    const mobileHistoryNewRunButtonRef = useRef<HTMLButtonElement | null>(null);
 
     const closeMobileHistory = useCallback(() => {
         setMobileHistoryOpen(false);
         openHistoryButtonRef.current?.focus();
     }, []);
+
+    useEffect(() => {
+        if (!isMobileHistoryOpen) return;
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                closeMobileHistory();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [isMobileHistoryOpen, closeMobileHistory]);
 
     const promptInputRef = useRef<HTMLTextAreaElement | null>(null);
     const agentEnsembleRef = useRef<AgentEnsembleHandles>(null);
@@ -977,7 +993,7 @@ const App: React.FC = () => {
             {isMobileHistoryOpen && (
                 <FocusTrap
                     focusTrapOptions={{
-                        initialFocus: '#mobile-history-new-run',
+                        initialFocus: () => mobileHistoryNewRunButtonRef.current!,
                         onDeactivate: () => openHistoryButtonRef.current?.focus(),
                     }}
                 >
@@ -991,6 +1007,7 @@ const App: React.FC = () => {
                             onViewCurrentRun={handleViewCurrentRunAndClose}
                             currentRunStatus={currentRunStatus}
                             className="relative h-full"
+                            newRunButtonRef={mobileHistoryNewRunButtonRef}
                         />
                     </div>
                 </FocusTrap>

--- a/App.tsx
+++ b/App.tsx
@@ -41,6 +41,7 @@ import FinalAnswerCard from '@/components/FinalAnswerCard';
 import HistorySidebar from '@/components/HistorySidebar';
 import SegmentedControl from '@/components/SegmentedControl';
 import useViewportHeight from '@/lib/useViewportHeight';
+import useKeydown from '@/lib/useKeydown';
 import FocusTrap from 'focus-trap-react';
 
 const OPENAI_API_KEY_STORAGE_KEY = 'openai_api_key';
@@ -221,21 +222,7 @@ const App: React.FC = () => {
         setMobileHistoryOpen(false);
         openHistoryButtonRef.current?.focus();
     }, []);
-
-    useEffect(() => {
-        if (!isMobileHistoryOpen) return;
-
-        const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                closeMobileHistory();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => {
-            document.removeEventListener('keydown', handleKeyDown);
-        };
-    }, [isMobileHistoryOpen, closeMobileHistory]);
+    useKeydown('Escape', closeMobileHistory, isMobileHistoryOpen);
 
     const promptInputRef = useRef<HTMLTextAreaElement | null>(null);
     const agentEnsembleRef = useRef<AgentEnsembleHandles>(null);

--- a/App.tsx
+++ b/App.tsx
@@ -980,13 +980,14 @@ const App: React.FC = () => {
             {isMobileHistoryOpen && (
                 <FocusTrap
                     focusTrapOptions={{
-                        initialFocus: () => mobileHistoryNewRunButtonRef.current!,
+                        initialFocus: () => mobileHistoryNewRunButtonRef.current ?? undefined,
                         onDeactivate: () => openHistoryButtonRef.current?.focus(),
                     }}
                 >
                     <div className="fixed inset-0 z-40 flex">
                         <div className="absolute inset-0 bg-black/50" onClick={closeMobileHistory}></div>
                         <HistorySidebar
+                            ref={mobileHistoryNewRunButtonRef}
                             history={history}
                             selectedRunId={selectedRunId}
                             onSelectRun={handleSelectRunAndClose}
@@ -994,7 +995,6 @@ const App: React.FC = () => {
                             onViewCurrentRun={handleViewCurrentRunAndClose}
                             currentRunStatus={currentRunStatus}
                             className="relative h-full"
-                            newRunButtonRef={mobileHistoryNewRunButtonRef}
                         />
                     </div>
                 </FocusTrap>

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, forwardRef } from 'react';
 import { RunRecord, RunStatus } from '@/types';
 import { ChevronLeftIcon, ChevronRightIcon, PlusIcon, CheckCircleIcon, XCircleIcon } from '@/components/icons';
 
@@ -13,7 +13,6 @@ interface HistorySidebarProps {
   onViewCurrentRun: () => void;
   currentRunStatus: CurrentRunStatus;
   className?: string;
-  newRunButtonRef?: React.Ref<HTMLButtonElement>;
 }
 
 const formatTimestamp = (timestamp: number): string => {
@@ -56,7 +55,15 @@ const StatusIndicator: React.FC<{ status: RunStatus }> = ({ status }) => {
 };
 
 
-const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId, onSelectRun, onNewRun, onViewCurrentRun, currentRunStatus, className, newRunButtonRef }) => {
+const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>(({
+    history,
+    selectedRunId,
+    onSelectRun,
+    onNewRun,
+    onViewCurrentRun,
+    currentRunStatus,
+    className,
+}, newRunButtonRef) => {
     const [isOpen, setIsOpen] = useState(true);
 
     return (
@@ -75,6 +82,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
             <div className="flex-shrink-0 p-2">
                 <button
                     ref={newRunButtonRef}
+                    id="new-run-button"
                     onClick={onNewRun}
                     className={`w-full flex items-center gap-3 px-3 py-2 text-sm font-semibold rounded-lg transition-colors ${
                         !selectedRunId ? 'bg-[var(--accent)] text-[#0D1411] hover:brightness-110' : 'bg-[var(--surface-1)] hover:bg-[var(--surface-active)] text-[var(--text)]'
@@ -138,6 +146,6 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
             </nav>
         </aside>
     );
-};
+});
 
 export default HistorySidebar;

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -13,6 +13,7 @@ interface HistorySidebarProps {
   onViewCurrentRun: () => void;
   currentRunStatus: CurrentRunStatus;
   className?: string;
+  newRunButtonRef?: React.Ref<HTMLButtonElement>;
 }
 
 const formatTimestamp = (timestamp: number): string => {
@@ -55,7 +56,7 @@ const StatusIndicator: React.FC<{ status: RunStatus }> = ({ status }) => {
 };
 
 
-const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId, onSelectRun, onNewRun, onViewCurrentRun, currentRunStatus, className }) => {
+const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId, onSelectRun, onNewRun, onViewCurrentRun, currentRunStatus, className, newRunButtonRef }) => {
     const [isOpen, setIsOpen] = useState(true);
 
     return (
@@ -73,7 +74,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
 
             <div className="flex-shrink-0 p-2">
                 <button
-                    id="mobile-history-new-run"
+                    ref={newRunButtonRef}
                     onClick={onNewRun}
                     className={`w-full flex items-center gap-3 px-3 py-2 text-sm font-semibold rounded-lg transition-colors ${
                         !selectedRunId ? 'bg-[var(--accent)] text-[#0D1411] hover:brightness-110' : 'bg-[var(--surface-1)] hover:bg-[var(--surface-active)] text-[var(--text)]'

--- a/focus-trap-react.d.ts
+++ b/focus-trap-react.d.ts
@@ -1,0 +1,1 @@
+declare module 'focus-trap-react';

--- a/lib/useKeydown.ts
+++ b/lib/useKeydown.ts
@@ -1,12 +1,18 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 const useKeydown = (key: string, callback: (e: KeyboardEvent) => void, active = true) => {
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
   useEffect(() => {
     if (!active) return;
 
     const handler = (event: KeyboardEvent) => {
       if (event.key === key) {
-        callback(event);
+        callbackRef.current(event);
       }
     };
 
@@ -14,7 +20,7 @@ const useKeydown = (key: string, callback: (e: KeyboardEvent) => void, active = 
     return () => {
       document.removeEventListener('keydown', handler);
     };
-  }, [key, callback, active]);
+  }, [key, active]);
 };
 
 export default useKeydown;

--- a/lib/useKeydown.ts
+++ b/lib/useKeydown.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+const useKeydown = (key: string, callback: (e: KeyboardEvent) => void, active = true) => {
+  useEffect(() => {
+    if (!active) return;
+
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === key) {
+        callback(event);
+      }
+    };
+
+    document.addEventListener('keydown', handler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+    };
+  }, [key, callback, active]);
+};
+
+export default useKeydown;


### PR DESCRIPTION
## Summary
- use ref for initial focus so focus trap activates on mobile history drawer
- close mobile history drawer with Escape key

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68afcc32898c8322b34bb2dc1ca67477