### PR TITLE
Improve mobile history focus handling and resize hooks

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -31,7 +31,7 @@ import { experts } from '@/moe/experts';
 import { runOrchestration } from '@/moe/orchestrator';
 import { Draft, ExpertDispatch } from '@/moe/types';
 import AgentCard from '@/components/AgentCard';
-import { ShieldCheckIcon, CogIcon, DownloadIcon, ExclamationTriangleIcon, XMarkIcon } from '@/components/icons';
+import { ShieldCheckIcon, CogIcon, DownloadIcon, ExclamationTriangleIcon, XMarkIcon, Bars3Icon } from '@/components/icons';
 import SettingsView from '@/components/SettingsView';
 import { setOpenAIApiKey as storeOpenAIApiKey, setGeminiApiKey as storeGeminiApiKey, setOpenRouterApiKey as storeOpenRouterApiKey } from '@/services/llmService';
 import CollapsibleSection from '@/components/CollapsibleSection';
@@ -40,6 +40,8 @@ import PromptInput from '@/components/PromptInput';
 import FinalAnswerCard from '@/components/FinalAnswerCard';
 import HistorySidebar from '@/components/HistorySidebar';
 import SegmentedControl from '@/components/SegmentedControl';
+import useViewportHeight from '@/lib/useViewportHeight';
+import FocusTrap from 'focus-trap-react';
 
 const OPENAI_API_KEY_STORAGE_KEY = 'openai_api_key';
 const GEMINI_API_KEY_STORAGE_KEY = 'gemini_api_key';
@@ -181,6 +183,7 @@ const mapDraftToAgentState = (draft: Draft): AgentState => ({
 });
 
 const App: React.FC = () => {
+    useViewportHeight();
     // Live state
     const [prompt, setPrompt] = useState<string>('');
     const [images, setImages] = useState<ImageState[]>([]);
@@ -210,6 +213,14 @@ const App: React.FC = () => {
     const [isSettingsViewOpen, setIsSettingsViewOpen] = useState<boolean>(false);
     const [queryHistory, setQueryHistory] = useState<string[]>([]);
     const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+    const [isMobileHistoryOpen, setMobileHistoryOpen] = useState(false);
+    const openHistoryButtonRef = useRef<HTMLButtonElement | null>(null);
+    const mobileNewRunRef = useRef<HTMLButtonElement | null>(null);
+
+    const closeMobileHistory = useCallback(() => {
+        setMobileHistoryOpen(false);
+        openHistoryButtonRef.current?.focus();
+    }, []);
 
     const promptInputRef = useRef<HTMLTextAreaElement | null>(null);
     const agentEnsembleRef = useRef<AgentEnsembleHandles>(null);
@@ -223,6 +234,7 @@ const App: React.FC = () => {
     const animationFrameId = useRef<number | null>(null);
     const isRunCompletedRef = useRef(false);
     const currentRunDataRef = useRef<Pick<RunRecord, 'prompt' | 'images' | 'agentConfigs' | 'arbiterModel' | 'openAIArbiterVerbosity' | 'geminiArbiterEffort'> | undefined>(undefined);
+
 
     useEffect(() => { finalAnswerRef.current = finalAnswer; }, [finalAnswer]);
     useEffect(() => { agentsRef.current = agents; }, [agents]);
@@ -439,12 +451,42 @@ const App: React.FC = () => {
         handleReset();
     }, [handleReset]);
 
+    const handleViewCurrentRun = useCallback(() => {
+        setSelectedRunId(null);
+    }, []);
+
     const handleSelectRun = useCallback((id: string) => {
         const run = history.find(r => r.id === id);
         if (run) {
             setSelectedRunId(id);
         }
     }, [history]);
+
+    const handleSelectRunAndClose = useCallback((id: string) => {
+        handleSelectRun(id);
+        closeMobileHistory();
+    }, [handleSelectRun, closeMobileHistory]);
+
+    const handleNewRunAndClose = useCallback(() => {
+        handleNewRun();
+        closeMobileHistory();
+    }, [handleNewRun, closeMobileHistory]);
+
+    const handleViewCurrentRunAndClose = useCallback(() => {
+        handleViewCurrentRun();
+        closeMobileHistory();
+    }, [handleViewCurrentRun, closeMobileHistory]);
+
+    useEffect(() => {
+        if (!isMobileHistoryOpen) return;
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                closeMobileHistory();
+            }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [isMobileHistoryOpen, closeMobileHistory]);
     
     const handleDuplicateAgent = useCallback((id: string) => {
         setAgentConfigs(prev => {
@@ -581,8 +623,7 @@ const App: React.FC = () => {
 
     useEffect(() => {
         isHistoryViewRef.current = displayData.isHistoryView;
-        agentsRef.current = displayData.agents;
-    }, [displayData]);
+    }, [displayData.isHistoryView]);
 
     const handleSaveAll = async () => {
         const dataToSave = displayData;
@@ -748,17 +789,19 @@ const App: React.FC = () => {
     }, [isRunning, error, hasResults, selectedRunId]);
 
     return (
-        <div className="min-h-screen bg-[var(--bg)] text-[var(--text)] font-sans flex h-screen">
-            <HistorySidebar 
+        <div className="bg-[var(--bg)] text-[var(--text)] font-sans flex" style={{ minHeight: 'calc(var(--vh, 1vh) * 100)' }}>
+            <HistorySidebar
                 history={history}
                 selectedRunId={selectedRunId}
                 onSelectRun={handleSelectRun}
                 onNewRun={handleNewRun}
+                onViewCurrentRun={handleViewCurrentRun}
                 currentRunStatus={currentRunStatus}
+                className="hidden md:flex"
             />
-            <div className="flex-1 flex flex-col h-screen">
+            <div className="flex-1 flex flex-col h-full">
                 {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
-                 <SettingsView
+                <SettingsView
                     isOpen={isSettingsViewOpen}
                     onClose={() => setIsSettingsViewOpen(false)}
                     onSaveOpenAIApiKey={handleSaveOpenAIApiKey}
@@ -772,9 +815,19 @@ const App: React.FC = () => {
                     queryHistory={queryHistory}
                     onSelectQuery={handleSelectQuery}
                 />
-                <div className="flex-1 overflow-y-auto">
+                <div className="flex-1 overflow-y-auto scrollable-area">
                     <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                        <header className="text-center py-8 relative">
+                        <header className="text-center py-8 relative fixed-header">
+                            <div className="absolute top-8 left-0 md:hidden">
+                                <button
+                                    ref={openHistoryButtonRef}
+                                    onClick={() => setMobileHistoryOpen(true)}
+                                    className="p-2 text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--surface-active)] rounded-lg"
+                                    aria-label="Open history"
+                                >
+                                    <Bars3Icon className="w-6 h-6" aria-hidden="true" />
+                                </button>
+                            </div>
                             <img src={`${import.meta.env.BASE_URL}assets/banner.svg`} alt="HeavyOrc banner" className="mx-auto mb-4 w-full max-w-2xl" />
                             <h1 className="text-4xl sm:text-5xl font-bold text-[var(--text)] flex items-center justify-center gap-3">
                                 <ShieldCheckIcon className="w-10 h-10 text-emerald-400" aria-hidden="true" />
@@ -908,7 +961,7 @@ const App: React.FC = () => {
                     </div>
                 </div>
 
-                <footer className="sticky bottom-0 z-10 bg-[var(--surface-1)] bg-opacity-80 backdrop-blur-lg border-t border-[var(--line)] flex-shrink-0">
+                <footer className="sticky bottom-0 z-10 bg-[var(--surface-1)] bg-opacity-80 backdrop-blur-lg border-t border-[var(--line)] flex-shrink-0 fixed-footer">
                     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-3 space-y-3">
                         {isLoading && (
                             <div>
@@ -933,6 +986,28 @@ const App: React.FC = () => {
                     </div>
                 </footer>
             </div>
+            {isMobileHistoryOpen && (
+                <FocusTrap
+                    focusTrapOptions={{
+                        initialFocus: () => mobileNewRunRef.current,
+                        onDeactivate: closeMobileHistory,
+                    }}
+                >
+                    <div className="fixed inset-0 z-40 flex">
+                        <div className="absolute inset-0 bg-black/50" onClick={closeMobileHistory}></div>
+                        <HistorySidebar
+                            history={history}
+                            selectedRunId={selectedRunId}
+                            onSelectRun={handleSelectRunAndClose}
+                            onNewRun={handleNewRunAndClose}
+                            onViewCurrentRun={handleViewCurrentRunAndClose}
+                            currentRunStatus={currentRunStatus}
+                            className="relative h-full"
+                            newRunRef={mobileNewRunRef}
+                        />
+                    </div>
+                </FocusTrap>
+            )}
         </div>
     );
 };

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -10,7 +10,10 @@ interface HistorySidebarProps {
   selectedRunId: string | null;
   onSelectRun: (id: string) => void;
   onNewRun: () => void;
+  onViewCurrentRun: () => void;
   currentRunStatus: CurrentRunStatus;
+  className?: string;
+  newRunRef?: React.Ref<HTMLButtonElement>;
 }
 
 const formatTimestamp = (timestamp: number): string => {
@@ -53,11 +56,11 @@ const StatusIndicator: React.FC<{ status: RunStatus }> = ({ status }) => {
 };
 
 
-const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId, onSelectRun, onNewRun, currentRunStatus }) => {
+const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId, onSelectRun, onNewRun, onViewCurrentRun, currentRunStatus, className, newRunRef }) => {
     const [isOpen, setIsOpen] = useState(true);
 
     return (
-        <aside className={`bg-[var(--surface-2)] border-r border-[var(--line)] flex flex-col transition-all duration-300 ease-in-out ${isOpen ? 'w-64' : 'w-16'}`}>
+        <aside className={`bg-[var(--surface-2)] border-r border-[var(--line)] flex flex-col transition-all duration-300 ease-in-out ${isOpen ? 'w-64' : 'w-16'} ${className ?? ''}`}>
             <div className="flex-shrink-0 p-2 flex items-center justify-between border-b border-[var(--line)]">
                 {isOpen && <h2 className="text-lg font-semibold ml-2">History</h2>}
                 <button
@@ -71,6 +74,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
 
             <div className="flex-shrink-0 p-2">
                 <button
+                    ref={newRunRef}
                     onClick={onNewRun}
                     className={`w-full flex items-center gap-3 px-3 py-2 text-sm font-semibold rounded-lg transition-colors ${
                         !selectedRunId ? 'bg-[var(--accent)] text-[#0D1411] hover:brightness-110' : 'bg-[var(--surface-1)] hover:bg-[var(--surface-active)] text-[var(--text)]'
@@ -86,11 +90,12 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ history, selectedRunId,
                      {currentRunStatus !== 'IDLE' && (
                         <li>
                             <button
-                                onClick={() => onNewRun()} // Resets to live view
+                                onClick={onViewCurrentRun} // View current run without resetting
                                 className={`w-full text-left flex items-center gap-3 p-2 rounded-md transition-colors ${
                                     !selectedRunId ? 'bg-[var(--surface-1)]' : 'hover:bg-[var(--surface-active)]'
                                 }`}
                                 title="View current run"
+                                aria-current={!selectedRunId ? 'page' : undefined}
                             >
                                 <div className="flex-shrink-0 w-4 h-4 flex items-center justify-center">
                                     <StatusIndicator status={currentRunStatus as RunStatus} />

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -39,6 +39,12 @@ export const EllipsisHorizontalIcon = (props: IconProps) => (
   </svg>
 );
 
+export const Bars3Icon = (props: IconProps) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" {...props}>
+    <path d="M2 4.75A.75.75 0 0 1 2.75 4h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 4.75Zm0 5A.75.75 0 0 1 2.75 9h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 9.75Zm0 5a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Z" />
+  </svg>
+);
+
 export const DownloadIcon = (props: IconProps) => (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" {...props}>
         <path d="M10.75 2.75a.75.75 0 0 0-1.5 0v8.614L6.295 8.235a.75.75 0 1 0-1.09 1.03l4.25 4.5a.75.75 0 0 0 1.09 0l4.25-4.5a.75.75 0 0 0-1.09-1.03l-2.955 3.129V2.75Z" />

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%assets/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>HeavyOrc</title>
     <script>
       tailwind.config = {
@@ -47,6 +47,28 @@
       body {
         background-color: var(--bg);
         color: var(--text);
+        padding-top: constant(safe-area-inset-top);
+        padding-top: env(safe-area-inset-top);
+        padding-bottom: constant(safe-area-inset-bottom);
+        padding-bottom: env(safe-area-inset-bottom);
+        padding-left: env(safe-area-inset-left);
+        padding-right: env(safe-area-inset-right);
+      }
+      .app-shell {
+        height: calc(var(--vh, 1vh) * 100);
+      }
+      .scrollable-area {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+        overscroll-behavior: contain;
+        scroll-padding-top: calc(16px + env(safe-area-inset-top));
+        scroll-padding-bottom: calc(16px + var(--keyboard-height, 0px));
+      }
+      .fixed-header {
+        padding-top: env(safe-area-inset-top);
+      }
+      .fixed-footer {
+        padding-bottom: max(16px, env(safe-area-inset-bottom));
       }
       /* For custom scrollbars to match the dark theme */
       html {
@@ -160,9 +182,9 @@
 }
 </script>
 </head>
-  <body class="bg-[var(--bg)] text-[var(--text)]">
+  <body class="app-shell bg-[var(--bg)] text-[var(--text)]">
     <div id="background-effects"></div>
-    <div id="root"></div>
+    <div id="root" class="h-full"></div>
     <script type="module" src="./index.tsx"></script>
   </body>
 </html>

--- a/lib/useComponentSize.ts
+++ b/lib/useComponentSize.ts
@@ -1,0 +1,36 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+export interface ComponentSize {
+  width: number;
+  height: number;
+}
+
+const useComponentSize = <T extends HTMLElement>() => {
+  const observerRef = useRef<ResizeObserver>();
+  const [size, setSize] = useState<ComponentSize>({ width: 0, height: 0 });
+
+  const ref = useCallback((node: T | null) => {
+    observerRef.current?.disconnect();
+
+    if (!node || typeof window === 'undefined' || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    observerRef.current = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        const { width, height } = entry.contentRect;
+        setSize({ width, height });
+      }
+    });
+    observerRef.current.observe(node);
+  }, []);
+
+  useEffect(() => {
+    return () => observerRef.current?.disconnect();
+  }, []);
+
+  return [ref, size] as const;
+};
+
+export default useComponentSize;

--- a/lib/useViewportHeight.ts
+++ b/lib/useViewportHeight.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+const useViewportHeight = () => {
+  const [vh, setVh] = useState(typeof window !== 'undefined' ? window.innerHeight * 0.01 : 0);
+
+  useEffect(() => {
+    const setDynamicVh = () => {
+      const vv = window.visualViewport;
+      const height = vv ? vv.height : window.innerHeight;
+      const newVh = height * 0.01;
+      document.documentElement.style.setProperty('--vh', `${newVh}px`);
+      if (vv) {
+        const keyboard = window.innerHeight - vv.height - vv.offsetTop;
+        document.documentElement.style.setProperty('--keyboard-height', `${keyboard}px`);
+      }
+      setVh(newVh);
+    };
+
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const debouncedSetDynamicVh = () => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(setDynamicVh, 100);
+    };
+
+    setDynamicVh();
+
+    window.addEventListener('resize', debouncedSetDynamicVh);
+    window.visualViewport?.addEventListener('resize', debouncedSetDynamicVh);
+    return () => {
+      window.removeEventListener('resize', debouncedSetDynamicVh);
+      window.visualViewport?.removeEventListener('resize', debouncedSetDynamicVh);
+      clearTimeout(timeoutId);
+    };
+  }, []);
+
+  return vh;
+};
+
+export default useViewportHeight;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@google/genai": "^1.15.0",
+        "focus-trap-react": "^11.0.4",
         "framer-motion": "^11.3.12",
         "jszip": "^3.10.1",
         "openai": "^4.52.7",
@@ -1236,14 +1237,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1254,7 +1253,6 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -1851,7 +1849,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2168,6 +2165,31 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.5.tgz",
+      "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.2.0"
+      }
+    },
+    "node_modules/focus-trap-react": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-11.0.4.tgz",
+      "integrity": "sha512-tC7jC/yqeAqhe4irNIzdyDf9XCtGSeECHiBSYJBO/vIN0asizbKZCt8TarB6/XqIceu42ajQ/U4lQJ9pZlWjrg==",
+      "license": "MIT",
+      "dependencies": {
+        "focus-trap": "^7.6.5",
+        "tabbable": "^6.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/foreground-child": {
@@ -4006,6 +4028,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "jszip": "^3.10.1",
     "openai": "^4.52.7",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "focus-trap-react": "^11.0.4"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",


### PR DESCRIPTION
## Summary
- use callback ref in history sidebar for new-run button and mark current run with aria-current
- close mobile history drawer on `Escape` and trap focus via ref
- guard `useComponentSize` against missing `ResizeObserver`

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68afc3aa6cd883228861f86ff759da12