### PR TITLE
Improve mobile history focus and resize robustness

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -995,6 +995,7 @@ const App: React.FC = () => {
                             onViewCurrentRun={handleViewCurrentRunAndClose}
                             currentRunStatus={currentRunStatus}
                             className="relative h-full"
+                            isMobile
                         />
                     </div>
                 </FocusTrap>

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -13,6 +13,7 @@ interface HistorySidebarProps {
   onViewCurrentRun: () => void;
   currentRunStatus: CurrentRunStatus;
   className?: string;
+  isMobile?: boolean;
 }
 
 const formatTimestamp = (timestamp: number): string => {
@@ -63,6 +64,7 @@ const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>(({
     onViewCurrentRun,
     currentRunStatus,
     className,
+    isMobile,
 }, newRunButtonRef) => {
     const [isOpen, setIsOpen] = useState(true);
 
@@ -82,7 +84,7 @@ const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>(({
             <div className="flex-shrink-0 p-2">
                 <button
                     ref={newRunButtonRef}
-                    id="new-run-button"
+                    id={isMobile ? 'mobile-history-new-run' : undefined}
                     onClick={onNewRun}
                     className={`w-full flex items-center gap-3 px-3 py-2 text-sm font-semibold rounded-lg transition-colors ${
                         !selectedRunId ? 'bg-[var(--accent)] text-[#0D1411] hover:brightness-110' : 'bg-[var(--surface-1)] hover:bg-[var(--surface-active)] text-[var(--text)]'
@@ -103,6 +105,7 @@ const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>(({
                                     !selectedRunId ? 'bg-[var(--surface-1)]' : 'hover:bg-[var(--surface-active)]'
                                 }`}
                                 title="View current run"
+                                aria-current={!selectedRunId ? 'page' : undefined}
                             >
                                 <div className="flex-shrink-0 w-4 h-4 flex items-center justify-center">
                                     <StatusIndicator status={currentRunStatus as RunStatus} />

--- a/index.html
+++ b/index.html
@@ -60,7 +60,6 @@
       .scrollable-area {
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
-        overscroll-behavior: contain;
         scroll-padding-top: calc(16px + env(safe-area-inset-top));
         scroll-padding-bottom: calc(16px + var(--keyboard-height, 0px));
       }

--- a/lib/useComponentSize.ts
+++ b/lib/useComponentSize.ts
@@ -12,7 +12,7 @@ const useComponentSize = <T extends HTMLElement>() => {
   const ref = useCallback((node: T | null) => {
     observerRef.current?.disconnect();
 
-    if (node) {
+    if (node && typeof ResizeObserver !== 'undefined') {
       observerRef.current = new ResizeObserver((entries) => {
         const entry = entries[0];
         if (entry) {

--- a/lib/useViewportHeight.ts
+++ b/lib/useViewportHeight.ts
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 const useViewportHeight = () => {
-  const [vh, setVh] = useState(typeof window !== 'undefined' ? window.innerHeight * 0.01 : 0);
+  const vhRef = useRef<number>(typeof window !== 'undefined' ? window.innerHeight * 0.01 : 0);
 
   useEffect(() => {
     const setDynamicVh = () => {
@@ -13,7 +13,7 @@ const useViewportHeight = () => {
         const keyboard = window.innerHeight - vv.height - vv.offsetTop;
         document.documentElement.style.setProperty('--keyboard-height', `${keyboard}px`);
       }
-      setVh(newVh);
+      vhRef.current = newVh;
     };
 
     let timeoutId: ReturnType<typeof setTimeout>;
@@ -33,7 +33,7 @@ const useViewportHeight = () => {
     };
   }, []);
 
-  return vh;
+  return vhRef;
 };
 
 export default useViewportHeight;


### PR DESCRIPTION
## Summary
- Ensure mobile history drawer focuses its own "New Run" button with a ref and avoid duplicated IDs
- Add `aria-current` to current run entry for better assistive feedback
- Guard `ResizeObserver` usage and refactor viewport height hook to prevent unnecessary renders
- Remove global `overscroll-behavior` to restore expected scroll interactions

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Missing script)*
- `npm run typecheck` *(fails: Missing script)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68afd64a9ae08322ad51b3b2ef9262e1