### PR TITLE
Add mobile history close control and clarify viewport hook API

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -780,7 +780,7 @@ const App: React.FC = () => {
     }, [isRunning, error, hasResults, selectedRunId]);
 
     return (
-        <div className="bg-[var(--bg)] text-[var(--text)] font-sans flex" style={{ minHeight: 'calc(var(--vh, 1vh) * 100)' }}>
+        <div className="bg-[var(--bg)] text-[var(--text)] font-sans flex w-full overflow-x-hidden" style={{ minHeight: 'calc(var(--vh, 1vh) * 100)' }}>
             <HistorySidebar
                 history={history}
                 selectedRunId={selectedRunId}
@@ -807,7 +807,7 @@ const App: React.FC = () => {
                     onSelectQuery={handleSelectQuery}
                 />
                 <div className="flex-1 overflow-y-auto scrollable-area">
-                    <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                    <div className="relative w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                         <header className="text-center py-8 relative fixed-header">
                             <div className="absolute top-8 left-0 md:hidden">
                                 <button

--- a/App.tsx
+++ b/App.tsx
@@ -996,6 +996,7 @@ const App: React.FC = () => {
                             currentRunStatus={currentRunStatus}
                             className="relative h-full"
                             isMobile
+                            onClose={closeMobileHistory}
                         />
                     </div>
                 </FocusTrap>

--- a/App.tsx
+++ b/App.tsx
@@ -780,7 +780,7 @@ const App: React.FC = () => {
     }, [isRunning, error, hasResults, selectedRunId]);
 
     return (
-        <div className="bg-[var(--bg)] text-[var(--text)] font-sans flex w-full overflow-x-hidden" style={{ minHeight: 'calc(var(--vh, 1vh) * 100)' }}>
+        <div className="bg-[var(--bg)] text-[var(--text)] font-sans flex w-full" style={{ minHeight: 'calc(var(--vh, 1vh) * 100)' }}>
             <HistorySidebar
                 history={history}
                 selectedRunId={selectedRunId}
@@ -790,7 +790,7 @@ const App: React.FC = () => {
                 currentRunStatus={currentRunStatus}
                 className="hidden md:flex"
             />
-            <div className="flex-1 flex flex-col h-full">
+            <div className="flex-1 flex flex-col h-full min-w-0">
                 {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
                 <SettingsView
                     isOpen={isSettingsViewOpen}

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -98,6 +98,7 @@ const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>((props
                         onClick={() => setIsOpen(!isOpen)}
                         className="p-2 text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--surface-active)] rounded-lg transition-colors"
                         title={isOpen ? "Collapse Sidebar" : "Expand Sidebar"}
+                        aria-label={isOpen ? "Collapse Sidebar" : "Expand Sidebar"}
                     >
                         {isOpen ? <ChevronLeftIcon className="w-6 h-6" aria-hidden="true" /> : <ChevronRightIcon className="w-6 h-6" aria-hidden="true" />}
                     </button>

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -81,7 +81,9 @@ const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>((props
     const [isOpen, setIsOpen] = useState(true);
 
     return (
-        <aside className={`bg-[var(--surface-2)] border-r border-[var(--line)] flex flex-col transition-all duration-300 ease-in-out ${isOpen ? 'w-64' : 'w-16'} ${className ?? ''} ${isMobile ? 'z-10' : ''}`}> 
+        <aside
+            className={`bg-[var(--surface-2)] border-r border-[var(--line)] flex flex-col transition-all duration-300 ease-in-out ${isOpen ? 'w-64' : 'w-16'}${className ? ` ${className}` : ''}${isMobile ? ' z-10' : ''}`}
+        >
             <div className="flex-shrink-0 p-2 flex items-center justify-between border-b border-[var(--line)]">
                 {isOpen && <h2 className="text-lg font-semibold ml-2">History</h2>}
                 {isMobile ? (

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -76,8 +76,8 @@ const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>((props
         onViewCurrentRun,
         currentRunStatus,
         className,
+        isMobile,
     } = props;
-    const isMobile = props.isMobile;
     const [isOpen, setIsOpen] = useState(true);
 
     return (

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -14,6 +14,7 @@ interface HistorySidebarProps {
   currentRunStatus: CurrentRunStatus;
   className?: string;
   isMobile?: boolean;
+  onClose?: () => void;
 }
 
 const formatTimestamp = (timestamp: number): string => {
@@ -56,7 +57,7 @@ const StatusIndicator: React.FC<{ status: RunStatus }> = ({ status }) => {
 };
 
 
-const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>(({
+const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>(({ 
     history,
     selectedRunId,
     onSelectRun,
@@ -65,6 +66,7 @@ const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>(({
     currentRunStatus,
     className,
     isMobile,
+    onClose,
 }, newRunButtonRef) => {
     const [isOpen, setIsOpen] = useState(true);
 
@@ -72,13 +74,24 @@ const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>(({
         <aside className={`bg-[var(--surface-2)] border-r border-[var(--line)] flex flex-col transition-all duration-300 ease-in-out ${isOpen ? 'w-64' : 'w-16'} ${className ?? ''}`}>
             <div className="flex-shrink-0 p-2 flex items-center justify-between border-b border-[var(--line)]">
                 {isOpen && <h2 className="text-lg font-semibold ml-2">History</h2>}
-                <button
-                    onClick={() => setIsOpen(!isOpen)}
-                    className="p-2 text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--surface-active)] rounded-lg transition-colors"
-                    title={isOpen ? "Collapse Sidebar" : "Expand Sidebar"}
-                >
-                    {isOpen ? <ChevronLeftIcon className="w-6 h-6" aria-hidden="true" /> : <ChevronRightIcon className="w-6 h-6" aria-hidden="true" />}
-                </button>
+                {isMobile ? (
+                    <button
+                        onClick={onClose}
+                        className="p-2 text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--surface-active)] rounded-lg transition-colors"
+                        title="Close History"
+                        aria-label="Close History"
+                    >
+                        <ChevronLeftIcon className="w-6 h-6" aria-hidden="true" />
+                    </button>
+                ) : (
+                    <button
+                        onClick={() => setIsOpen(!isOpen)}
+                        className="p-2 text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--surface-active)] rounded-lg transition-colors"
+                        title={isOpen ? "Collapse Sidebar" : "Expand Sidebar"}
+                    >
+                        {isOpen ? <ChevronLeftIcon className="w-6 h-6" aria-hidden="true" /> : <ChevronRightIcon className="w-6 h-6" aria-hidden="true" />}
+                    </button>
+                )}
             </div>
 
             <div className="flex-shrink-0 p-2">

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -5,7 +5,7 @@ import { ChevronLeftIcon, ChevronRightIcon, PlusIcon, CheckCircleIcon, XCircleIc
 
 type CurrentRunStatus = 'IDLE' | RunStatus;
 
-interface HistorySidebarProps {
+interface HistorySidebarBaseProps {
   history: RunRecord[];
   selectedRunId: string | null;
   onSelectRun: (id: string) => void;
@@ -13,9 +13,19 @@ interface HistorySidebarProps {
   onViewCurrentRun: () => void;
   currentRunStatus: CurrentRunStatus;
   className?: string;
-  isMobile?: boolean;
-  onClose?: () => void;
 }
+
+interface MobileHistorySidebarProps extends HistorySidebarBaseProps {
+  isMobile: true;
+  onClose: () => void;
+}
+
+interface DesktopHistorySidebarProps extends HistorySidebarBaseProps {
+  isMobile?: false;
+  onClose?: never;
+}
+
+type HistorySidebarProps = MobileHistorySidebarProps | DesktopHistorySidebarProps;
 
 const formatTimestamp = (timestamp: number): string => {
     const now = new Date();
@@ -57,26 +67,26 @@ const StatusIndicator: React.FC<{ status: RunStatus }> = ({ status }) => {
 };
 
 
-const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>(({ 
-    history,
-    selectedRunId,
-    onSelectRun,
-    onNewRun,
-    onViewCurrentRun,
-    currentRunStatus,
-    className,
-    isMobile,
-    onClose,
-}, newRunButtonRef) => {
+const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>((props, newRunButtonRef) => {
+    const {
+        history,
+        selectedRunId,
+        onSelectRun,
+        onNewRun,
+        onViewCurrentRun,
+        currentRunStatus,
+        className,
+    } = props;
+    const isMobile = props.isMobile;
     const [isOpen, setIsOpen] = useState(true);
 
     return (
-        <aside className={`bg-[var(--surface-2)] border-r border-[var(--line)] flex flex-col transition-all duration-300 ease-in-out ${isOpen ? 'w-64' : 'w-16'} ${className ?? ''}`}>
+        <aside className={`bg-[var(--surface-2)] border-r border-[var(--line)] flex flex-col transition-all duration-300 ease-in-out ${isOpen ? 'w-64' : 'w-16'} ${className ?? ''} ${isMobile ? 'z-10' : ''}`}> 
             <div className="flex-shrink-0 p-2 flex items-center justify-between border-b border-[var(--line)]">
                 {isOpen && <h2 className="text-lg font-semibold ml-2">History</h2>}
                 {isMobile ? (
                     <button
-                        onClick={onClose}
+                        onClick={props.onClose}
                         className="p-2 text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--surface-active)] rounded-lg transition-colors"
                         title="Close History"
                         aria-label="Close History"

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -322,18 +322,17 @@ const SettingsView: React.FC<SettingsViewProps> = (props) => {
 
     return (
         <div
-            className="fixed inset-0 bg-black/60 backdrop-blur-sm flex justify-center items-center z-50 animate-fade-in-up p-4"
+            className="fixed inset-0 z-50 flex justify-center items-center animate-fade-in-up p-4"
             style={{ animationDuration: '0.3s'}}
-            onClick={onClose}
             role="dialog"
             aria-modal="true"
             aria-labelledby="settings-title"
         >
+            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose}></div>
             <div
                 ref={dialogRef}
                 tabIndex={-1}
-                className="bg-[var(--surface-2)] rounded-xl shadow-2xl border border-[var(--line)] w-full max-w-4xl h-full max-h-[700px] flex flex-col"
-                onClick={e => e.stopPropagation()}
+                className="relative z-10 bg-[var(--surface-2)] rounded-xl shadow-2xl border border-[var(--line)] w-full max-w-4xl h-full max-h-[700px] flex flex-col"
             >
                 {/* --- Header --- */}
                 <header className="flex items-center justify-between p-4 border-b border-[var(--line)] flex-shrink-0">

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
         padding-bottom: env(safe-area-inset-bottom);
         padding-left: env(safe-area-inset-left);
         padding-right: env(safe-area-inset-right);
+        overflow-x: hidden;
       }
       .app-shell {
         height: calc(var(--vh, 1vh) * 100);

--- a/index.html
+++ b/index.html
@@ -44,6 +44,14 @@
         --warn: #D7A152;
         --success: #7FBF8A;
       }
+      html {
+        box-sizing: border-box;
+      }
+
+      *, *::before, *::after {
+        box-sizing: inherit;
+      }
+
       body {
         background-color: var(--bg);
         color: var(--text);
@@ -53,7 +61,6 @@
         padding-bottom: env(safe-area-inset-bottom);
         padding-left: env(safe-area-inset-left);
         padding-right: env(safe-area-inset-right);
-        overflow-x: hidden;
       }
       .app-shell {
         height: calc(var(--vh, 1vh) * 100);

--- a/lib/useViewportHeight.ts
+++ b/lib/useViewportHeight.ts
@@ -1,6 +1,11 @@
 import { useEffect, useRef } from 'react';
 
-const useViewportHeight = () => {
+/**
+ * Keeps CSS `--vh` and `--keyboard-height` variables in sync with the viewport
+ * height without triggering re-renders. The hook performs its work via
+ * side-effects and doesn't return a value.
+ */
+const useViewportHeight = (): void => {
   const vhRef = useRef<number>(typeof window !== 'undefined' ? window.innerHeight * 0.01 : 0);
 
   useEffect(() => {
@@ -32,8 +37,6 @@ const useViewportHeight = () => {
       clearTimeout(timeoutId);
     };
   }, []);
-
-  return vhRef;
 };
 
 export default useViewportHeight;

--- a/lib/useViewportHeight.ts
+++ b/lib/useViewportHeight.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 /**
  * Keeps CSS `--vh` and `--keyboard-height` variables in sync with the viewport
@@ -6,8 +6,6 @@ import { useEffect, useRef } from 'react';
  * side-effects and doesn't return a value.
  */
 const useViewportHeight = (): void => {
-  const vhRef = useRef<number>(typeof window !== 'undefined' ? window.innerHeight * 0.01 : 0);
-
   useEffect(() => {
     const setDynamicVh = () => {
       const vv = window.visualViewport;
@@ -18,7 +16,6 @@ const useViewportHeight = (): void => {
         const keyboard = window.innerHeight - vv.height - vv.offsetTop;
         document.documentElement.style.setProperty('--keyboard-height', `${keyboard}px`);
       }
-      vhRef.current = newVh;
     };
 
     let timeoutId: ReturnType<typeof setTimeout>;


### PR DESCRIPTION
## Summary
- add close/back button to mobile history sidebar
- improve useViewportHeight hook documentation and remove return value

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68afd99df01483228a821ee07e85de9e