### PR TITLE
Fix banner path and enhance segmented control

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -38,6 +38,7 @@ import CollapsibleSection from '@/components/CollapsibleSection';
 import AgentEnsemble, { AgentEnsembleHandles } from '@/components/AgentEnsemble';
 import PromptInput from '@/components/PromptInput';
 import FinalAnswerCard from '@/components/FinalAnswerCard';
+import banner from './.github/assets/banner.png';
 import HistorySidebar from '@/components/HistorySidebar';
 import SegmentedControl from '@/components/SegmentedControl';
 import useViewportHeight from '@/lib/useViewportHeight';
@@ -819,7 +820,13 @@ const App: React.FC = () => {
                                     <Bars3Icon className="w-6 h-6" aria-hidden="true" />
                                 </button>
                             </div>
-                            <img src={`${import.meta.env.BASE_URL}assets/banner.png`} alt="HeavyOrc banner" className="mx-auto mb-4 w-full max-w-2xl h-auto" />
+                            <img
+                                src={banner}
+                                alt="HeavyOrc banner"
+                                width={1200}
+                                height={300}
+                                className="mx-auto mb-4 w-full max-w-2xl h-auto"
+                            />
                             <h1 className="text-4xl sm:text-5xl font-bold text-[var(--text)] flex items-center justify-center gap-3">
                                 <ShieldCheckIcon className="w-10 h-10 text-emerald-400" aria-hidden="true" />
                                 HeavyOrc

--- a/components/SegmentedControl.tsx
+++ b/components/SegmentedControl.tsx
@@ -19,7 +19,8 @@ const SegmentedControl = <T extends string>({ options, value, onChange, disabled
     <div
       role="tablist"
       aria-label={ariaLabel}
-      className={`flex w-full p-1 bg-[var(--surface-1)] border border-[var(--line)] rounded-lg overflow-x-auto sm:overflow-x-visible ${disabled ? 'opacity-70 cursor-not-allowed' : ''}`}
+      aria-orientation="horizontal"
+      className={`flex w-full p-1 bg-[var(--surface-1)] border border-[var(--line)] rounded-lg overflow-x-auto sm:overflow-x-visible [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] ${disabled ? 'opacity-70 cursor-not-allowed' : ''}`}
     >
       {options.map((option, index) => (
         <button
@@ -31,7 +32,7 @@ const SegmentedControl = <T extends string>({ options, value, onChange, disabled
           disabled={disabled}
           aria-disabled={disabled}
           title={option.tooltip}
-          className={`relative px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-1)] z-10 whitespace-nowrap flex-none sm:flex-1
+          className={`relative px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-1)] z-10 whitespace-nowrap flex-none sm:flex-1 max-w-[8rem] truncate
             ${index === 0 ? 'rounded-l-md' : ''}
             ${index === options.length - 1 ? 'rounded-r-md' : ''}
             ${value === option.value ? 'text-[#0D1411]' : 'text-[var(--text)] hover:bg-[var(--surface-active)]'}


### PR DESCRIPTION
## Summary
- Import banner PNG directly and include fixed dimensions to avoid broken image and layout shifts
- Improve segmented control accessibility with horizontal orientation, hidden scrollbars, and truncated labels

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b2698df8048322b4bfdd1e07b4f1a0