### PR TITLE
Allow loading older session files

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -729,8 +729,8 @@ const App: React.FC = () => {
 
                 const data = JSON.parse(jsonString) as SessionData;
 
-                if (data.version !== SESSION_DATA_VERSION) {
-                    setToast({ message: `This session file is from a different version (v${data.version}) and cannot be loaded.`, type: 'error' });
+                if (data.version > SESSION_DATA_VERSION) {
+                    setToast({ message: `This session file is from a newer version (v${data.version}) and cannot be loaded.`, type: 'error' });
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- accept session files from older app versions
- only reject session data from newer versions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2776a2bc083228d6c79cbfa8cd8b2