### PR TITLE
Allow loading older session files

### DIFF
--- a/lib/sessionMigration.ts
+++ b/lib/sessionMigration.ts
@@ -1,0 +1,204 @@
+import {
+    AgentConfig,
+    GeminiAgentConfig,
+    OpenAIAgentConfig,
+    OpenRouterAgentConfig,
+    GeminiAgentSettings,
+    OpenAIAgentSettings,
+    OpenRouterAgentSettings,
+    SavedAgentConfig,
+    GeminiThinkingEffort,
+    OpenAIReasoningEffort,
+    OpenAIVerbosity,
+    GenerationStrategy,
+    GeminiModel,
+    OpenAIModel,
+    OpenRouterModel,
+    Expert,
+} from '@/types';
+import {
+    GEMINI_FLASH_MODEL,
+    GEMINI_PRO_MODEL,
+    OPENAI_AGENT_MODEL,
+    OPENAI_GPT5_MINI_MODEL,
+    OPENROUTER_GPT_4O,
+} from '@/constants';
+
+const VALID_GENERATION_STRATEGIES: GenerationStrategy[] = [
+    'single',
+    'deepconf-offline',
+    'deepconf-online',
+];
+
+const GEMINI_EFFORT_VALUES: readonly GeminiThinkingEffort[] = [
+    'dynamic',
+    'high',
+    'medium',
+    'low',
+    'none',
+];
+const isGeminiThinkingEffort = (value: unknown): value is GeminiThinkingEffort =>
+    typeof value === 'string' &&
+    GEMINI_EFFORT_VALUES.includes(value as GeminiThinkingEffort);
+
+const OPENAI_EFFORT_VALUES: readonly OpenAIReasoningEffort[] = ['medium', 'high'];
+const isOpenAIReasoningEffort = (
+    value: unknown,
+): value is OpenAIReasoningEffort =>
+    typeof value === 'string' &&
+    OPENAI_EFFORT_VALUES.includes(value as OpenAIReasoningEffort);
+
+const OPENAI_VERBOSITY_VALUES: readonly OpenAIVerbosity[] = [
+    'low',
+    'medium',
+    'high',
+];
+const isOpenAIVerbosity = (value: unknown): value is OpenAIVerbosity =>
+    typeof value === 'string' &&
+    OPENAI_VERBOSITY_VALUES.includes(value as OpenAIVerbosity);
+
+const migrateOpenRouterSettings = (
+    partial: Partial<OpenRouterAgentSettings>,
+): OpenRouterAgentSettings => ({
+    temperature: typeof partial.temperature === 'number' ? partial.temperature : 0.7,
+    topP: typeof partial.topP === 'number' ? partial.topP : 1,
+    topK: typeof partial.topK === 'number' ? partial.topK : 50,
+    frequencyPenalty:
+        typeof partial.frequencyPenalty === 'number' ? partial.frequencyPenalty : 0,
+    presencePenalty:
+        typeof partial.presencePenalty === 'number' ? partial.presencePenalty : 0,
+    repetitionPenalty:
+        typeof partial.repetitionPenalty === 'number' ? partial.repetitionPenalty : 1,
+    maxTokens: typeof partial.maxTokens === 'number' ? partial.maxTokens : undefined,
+});
+
+const migrateCommonSettings = (
+    partial: Partial<GeminiAgentSettings | OpenAIAgentSettings>,
+): Pick<
+    GeminiAgentSettings,
+    'generationStrategy' | 'confidenceSource' | 'traceCount' | 'deepConfEta' | 'tau' | 'groupWindow'
+> => ({
+    generationStrategy: VALID_GENERATION_STRATEGIES.includes(
+        partial.generationStrategy as GenerationStrategy,
+    )
+        ? (partial.generationStrategy as GenerationStrategy)
+        : 'single',
+    confidenceSource: 'judge',
+    traceCount:
+        typeof partial.traceCount === 'number' ? partial.traceCount : 8,
+    deepConfEta:
+        partial.deepConfEta === 10 || partial.deepConfEta === 90 ? partial.deepConfEta : 90,
+    tau: typeof partial.tau === 'number' ? partial.tau : 0.95,
+    groupWindow:
+        typeof partial.groupWindow === 'number' ? partial.groupWindow : 2048,
+});
+
+export const migrateAgentConfig = (
+    savedConfig: SavedAgentConfig,
+    expertList: Expert[],
+): AgentConfig | null => {
+    const expert = expertList.find((e) => e.id === savedConfig.expertId);
+    if (!expert) {
+        console.warn(
+            `Expert with ID "${savedConfig.expertId}" not found. Skipping.`,
+        );
+        return null;
+    }
+
+    const baseConfig = {
+        id: crypto.randomUUID(),
+        expert,
+        status: 'PENDING' as const,
+    };
+
+    const provider = savedConfig.provider;
+
+    switch (provider) {
+        case 'gemini': {
+            const model: GeminiModel =
+                savedConfig.model === GEMINI_FLASH_MODEL ||
+                savedConfig.model === GEMINI_PRO_MODEL
+                    ? (savedConfig.model as GeminiModel)
+                    : GEMINI_FLASH_MODEL;
+            const rawSettings =
+                savedConfig.settings &&
+                typeof savedConfig.settings === 'object'
+                    ? (savedConfig.settings as Partial<GeminiAgentSettings>)
+                    : {};
+            const effort: GeminiThinkingEffort = isGeminiThinkingEffort(
+                rawSettings.effort,
+            )
+                ? rawSettings.effort
+                : 'dynamic';
+            const migratedSettings: GeminiAgentSettings = {
+                ...migrateCommonSettings(rawSettings),
+                effort,
+            };
+            return {
+                ...baseConfig,
+                model,
+                provider: 'gemini',
+                settings: migratedSettings,
+            } as GeminiAgentConfig;
+        }
+
+        case 'openai': {
+            const model: OpenAIModel =
+                savedConfig.model === OPENAI_AGENT_MODEL ||
+                savedConfig.model === OPENAI_GPT5_MINI_MODEL
+                    ? (savedConfig.model as OpenAIModel)
+                    : OPENAI_AGENT_MODEL;
+            const rawSettings =
+                savedConfig.settings &&
+                typeof savedConfig.settings === 'object'
+                    ? (savedConfig.settings as Partial<OpenAIAgentSettings>)
+                    : {};
+            const effort: OpenAIReasoningEffort = isOpenAIReasoningEffort(
+                rawSettings.effort,
+            )
+                ? rawSettings.effort
+                : 'medium';
+            const verbosity: OpenAIVerbosity = isOpenAIVerbosity(
+                rawSettings.verbosity,
+            )
+                ? rawSettings.verbosity
+                : 'medium';
+            const migratedSettings: OpenAIAgentSettings = {
+                ...migrateCommonSettings(rawSettings),
+                effort,
+                verbosity,
+            };
+            return {
+                ...baseConfig,
+                model,
+                provider: 'openai',
+                settings: migratedSettings,
+            } as OpenAIAgentConfig;
+        }
+
+        case 'openrouter': {
+            const model =
+                typeof savedConfig.model === 'string'
+                    ? (savedConfig.model as OpenRouterModel)
+                    : OPENROUTER_GPT_4O;
+            const rawSettings =
+                savedConfig.settings &&
+                typeof savedConfig.settings === 'object'
+                    ? (savedConfig.settings as Partial<OpenRouterAgentSettings>)
+                    : {};
+            const migratedSettings = migrateOpenRouterSettings(rawSettings);
+            return {
+                ...baseConfig,
+                model,
+                provider: 'openrouter',
+                settings: migratedSettings,
+            } as OpenRouterAgentConfig;
+        }
+
+        default:
+            console.warn(
+                `Unknown provider "${provider}" for expert "${savedConfig.expertId}". Skipping.`,
+            );
+            return null;
+    }
+};


### PR DESCRIPTION
## Summary
- accept session files from older app versions
- only reject session data from newer or invalid versions
- populate default agent settings (Gemini, OpenAI, OpenRouter) when loading pre-v2 sessions
- migrate agent configurations in provider-specific branches and skip unknown providers
- extract migration helpers into a dedicated `lib/sessionMigration` module to keep `App.tsx` focused
- guard against missing settings objects and switch on provider for clearer migration
- validate models and per-provider settings when migrating to avoid malformed data crashing the app
- use type guards for Gemini and OpenAI effort/verbosity and centralize OpenRouter defaults

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2776a2bc083228d6c79cbfa8cd8b2