### PR TITLE
refactor: extract session migration helpers

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,9 +11,6 @@ import {
     GeminiAgentConfig,
     OpenAIAgentConfig,
     OpenRouterAgentConfig,
-    GeminiAgentSettings,
-    OpenAIAgentSettings,
-    OpenRouterAgentSettings,
     ArbiterModel,
     OpenAIVerbosity,
     SessionData,
@@ -23,10 +20,6 @@ import {
     GeminiThinkingEffort,
     RunStatus,
     OpenAIReasoningEffort,
-    GeminiModel,
-    OpenAIModel,
-    OpenRouterModel,
-    GenerationStrategy
 } from '@/types';
 import {
     GEMINI_PRO_MODEL,
@@ -64,6 +57,9 @@ import {
 // Hooks
 import useViewportHeight from '@/lib/useViewportHeight';
 import useKeydown from '@/lib/useKeydown';
+
+// Session migration
+import { migrateAgentConfig } from '@/lib/sessionMigration';
 
 // Assets
 import banner from './assets/banner.png';
@@ -206,170 +202,6 @@ const mapDraftToAgentState = (draft: Draft): AgentState => ({
     model: draft.expert.model,
     provider: draft.expert.provider,
 });
-
-const VALID_GENERATION_STRATEGIES: GenerationStrategy[] = [
-    'single',
-    'deepconf-offline',
-    'deepconf-online',
-];
-
-const GEMINI_EFFORT_VALUES: readonly GeminiThinkingEffort[] = [
-    'dynamic',
-    'high',
-    'medium',
-    'low',
-    'none',
-];
-const isGeminiThinkingEffort = (value: unknown): value is GeminiThinkingEffort =>
-    typeof value === 'string' &&
-    GEMINI_EFFORT_VALUES.includes(value as GeminiThinkingEffort);
-
-const OPENAI_EFFORT_VALUES: readonly OpenAIReasoningEffort[] = ['medium', 'high'];
-const isOpenAIReasoningEffort = (value: unknown): value is OpenAIReasoningEffort =>
-    typeof value === 'string' &&
-    OPENAI_EFFORT_VALUES.includes(value as OpenAIReasoningEffort);
-
-const OPENAI_VERBOSITY_VALUES: readonly OpenAIVerbosity[] = ['low', 'medium', 'high'];
-const isOpenAIVerbosity = (value: unknown): value is OpenAIVerbosity =>
-    typeof value === 'string' &&
-    OPENAI_VERBOSITY_VALUES.includes(value as OpenAIVerbosity);
-
-const migrateOpenRouterSettings = (
-    partial: Partial<OpenRouterAgentSettings>,
-): OpenRouterAgentSettings => ({
-    temperature: typeof partial.temperature === 'number' ? partial.temperature : 0.7,
-    topP: typeof partial.topP === 'number' ? partial.topP : 1,
-    topK: typeof partial.topK === 'number' ? partial.topK : 50,
-    frequencyPenalty:
-        typeof partial.frequencyPenalty === 'number' ? partial.frequencyPenalty : 0,
-    presencePenalty:
-        typeof partial.presencePenalty === 'number' ? partial.presencePenalty : 0,
-    repetitionPenalty:
-        typeof partial.repetitionPenalty === 'number' ? partial.repetitionPenalty : 1,
-    maxTokens: typeof partial.maxTokens === 'number' ? partial.maxTokens : undefined,
-});
-
-const migrateCommonSettings = (
-    partial: Partial<GeminiAgentSettings | OpenAIAgentSettings>,
-): Pick<
-    GeminiAgentSettings,
-    'generationStrategy' | 'confidenceSource' | 'traceCount' | 'deepConfEta' | 'tau' | 'groupWindow'
-> => ({
-    generationStrategy: VALID_GENERATION_STRATEGIES.includes(
-        partial.generationStrategy as GenerationStrategy,
-    )
-        ? (partial.generationStrategy as GenerationStrategy)
-        : 'single',
-    confidenceSource: 'judge',
-    traceCount:
-        typeof partial.traceCount === 'number' ? partial.traceCount : 8,
-    deepConfEta: partial.deepConfEta === 10 || partial.deepConfEta === 90 ? partial.deepConfEta : 90,
-    tau: typeof partial.tau === 'number' ? partial.tau : 0.95,
-    groupWindow:
-        typeof partial.groupWindow === 'number' ? partial.groupWindow : 2048,
-});
-
-const migrateAgentConfig = (
-    savedConfig: SavedAgentConfig,
-    expertList: typeof experts,
-): AgentConfig | null => {
-    const expert = expertList.find((e) => e.id === savedConfig.expertId);
-    if (!expert) {
-        console.warn(`Expert with ID "${savedConfig.expertId}" not found. Skipping.`);
-        return null;
-    }
-
-    const baseConfig = {
-        id: crypto.randomUUID(),
-        expert,
-        status: 'PENDING' as const,
-    };
-
-    const provider = savedConfig.provider;
-
-    switch (provider) {
-        case 'gemini': {
-            const model: GeminiModel =
-                savedConfig.model === GEMINI_FLASH_MODEL ||
-                savedConfig.model === GEMINI_PRO_MODEL
-                    ? savedConfig.model
-                    : GEMINI_FLASH_MODEL;
-            const rawSettings =
-                savedConfig.settings &&
-                typeof savedConfig.settings === 'object'
-                    ? (savedConfig.settings as Partial<GeminiAgentSettings>)
-                    : {};
-            const effort: GeminiThinkingEffort = isGeminiThinkingEffort(rawSettings.effort)
-                ? rawSettings.effort
-                : 'dynamic';
-            const migratedSettings: GeminiAgentSettings = {
-                ...migrateCommonSettings(rawSettings),
-                effort,
-            };
-            return {
-                ...baseConfig,
-                model,
-                provider: 'gemini',
-                settings: migratedSettings,
-            } as GeminiAgentConfig;
-        }
-
-        case 'openai': {
-            const model: OpenAIModel =
-                savedConfig.model === OPENAI_AGENT_MODEL ||
-                savedConfig.model === OPENAI_GPT5_MINI_MODEL
-                    ? savedConfig.model
-                    : OPENAI_AGENT_MODEL;
-            const rawSettings =
-                savedConfig.settings &&
-                typeof savedConfig.settings === 'object'
-                    ? (savedConfig.settings as Partial<OpenAIAgentSettings>)
-                    : {};
-            const effort: OpenAIReasoningEffort = isOpenAIReasoningEffort(rawSettings.effort)
-                ? rawSettings.effort
-                : 'medium';
-            const verbosity: OpenAIVerbosity = isOpenAIVerbosity(rawSettings.verbosity)
-                ? rawSettings.verbosity
-                : 'medium';
-            const migratedSettings: OpenAIAgentSettings = {
-                ...migrateCommonSettings(rawSettings),
-                effort,
-                verbosity,
-            };
-            return {
-                ...baseConfig,
-                model,
-                provider: 'openai',
-                settings: migratedSettings,
-            } as OpenAIAgentConfig;
-        }
-
-        case 'openrouter': {
-            const model =
-                typeof savedConfig.model === 'string'
-                    ? savedConfig.model
-                    : OPENROUTER_GPT_4O;
-            const rawSettings =
-                savedConfig.settings &&
-                typeof savedConfig.settings === 'object'
-                    ? (savedConfig.settings as Partial<OpenRouterAgentSettings>)
-                    : {};
-            const migratedSettings = migrateOpenRouterSettings(rawSettings);
-            return {
-                ...baseConfig,
-                model,
-                provider: 'openrouter',
-                settings: migratedSettings,
-            } as OpenRouterAgentConfig;
-        }
-
-        default:
-            console.warn(
-                `Unknown provider "${provider}" for expert "${savedConfig.expertId}". Skipping.`,
-            );
-            return null;
-    }
-};
 
 const App: React.FC = () => {
     useViewportHeight();

--- a/lib/sessionMigration.ts
+++ b/lib/sessionMigration.ts
@@ -151,12 +151,12 @@ export const migrateAgentConfig = (
             const effort: OpenAIReasoningEffort = isOpenAIReasoningEffort(
                 openAISettings.effort,
             )
-                ? openAISettings.effort!
+                ? openAISettings.effort
                 : 'medium';
             const verbosity: OpenAIVerbosity = isOpenAIVerbosity(
                 openAISettings.verbosity,
             )
-                ? openAISettings.verbosity!
+                ? openAISettings.verbosity
                 : 'medium';
             const migratedSettings: OpenAIAgentSettings = {
                 ...migrateCommonSettings(openAISettings),

--- a/lib/sessionMigration.ts
+++ b/lib/sessionMigration.ts
@@ -127,7 +127,7 @@ export const migrateAgentConfig = (
             const effort: GeminiThinkingEffort = isGeminiThinkingEffort(
                 geminiSettings.effort,
             )
-                ? geminiSettings.effort!
+                ? geminiSettings.effort
                 : 'dynamic';
             const migratedSettings: GeminiAgentSettings = {
                 ...migrateCommonSettings(geminiSettings),

--- a/lib/sessionMigration.ts
+++ b/lib/sessionMigration.ts
@@ -1,0 +1,196 @@
+import {
+    AgentConfig,
+    GeminiAgentConfig,
+    OpenAIAgentConfig,
+    OpenRouterAgentConfig,
+    GeminiAgentSettings,
+    OpenAIAgentSettings,
+    OpenRouterAgentSettings,
+    SavedAgentConfig,
+    GeminiThinkingEffort,
+    OpenAIReasoningEffort,
+    OpenAIVerbosity,
+    GenerationStrategy,
+    Expert,
+    GeminiModel,
+    OpenAIModel,
+} from '@/types';
+import {
+    GEMINI_FLASH_MODEL,
+    GEMINI_PRO_MODEL,
+    OPENAI_AGENT_MODEL,
+    OPENAI_GPT5_MINI_MODEL,
+    OPENROUTER_GPT_4O,
+} from '@/constants';
+
+const VALID_GENERATION_STRATEGIES: GenerationStrategy[] = [
+    'single',
+    'deepconf-offline',
+    'deepconf-online',
+];
+
+const GEMINI_EFFORT_VALUES: readonly GeminiThinkingEffort[] = [
+    'dynamic',
+    'high',
+    'medium',
+    'low',
+    'none',
+];
+const isGeminiThinkingEffort = (value: unknown): value is GeminiThinkingEffort =>
+    typeof value === 'string' &&
+    GEMINI_EFFORT_VALUES.includes(value as GeminiThinkingEffort);
+
+const OPENAI_EFFORT_VALUES: readonly OpenAIReasoningEffort[] = ['medium', 'high'];
+const isOpenAIReasoningEffort = (
+    value: unknown,
+): value is OpenAIReasoningEffort =>
+    typeof value === 'string' &&
+    OPENAI_EFFORT_VALUES.includes(value as OpenAIReasoningEffort);
+
+const OPENAI_VERBOSITY_VALUES: readonly OpenAIVerbosity[] = [
+    'low',
+    'medium',
+    'high',
+];
+const isOpenAIVerbosity = (value: unknown): value is OpenAIVerbosity =>
+    typeof value === 'string' &&
+    OPENAI_VERBOSITY_VALUES.includes(value as OpenAIVerbosity);
+
+const migrateOpenRouterSettings = (
+    partial: Partial<OpenRouterAgentSettings>,
+): OpenRouterAgentSettings => ({
+    temperature: typeof partial.temperature === 'number' ? partial.temperature : 0.7,
+    topP: typeof partial.topP === 'number' ? partial.topP : 1,
+    topK: typeof partial.topK === 'number' ? partial.topK : 50,
+    frequencyPenalty:
+        typeof partial.frequencyPenalty === 'number' ? partial.frequencyPenalty : 0,
+    presencePenalty:
+        typeof partial.presencePenalty === 'number' ? partial.presencePenalty : 0,
+    repetitionPenalty:
+        typeof partial.repetitionPenalty === 'number' ? partial.repetitionPenalty : 1,
+    maxTokens: typeof partial.maxTokens === 'number' ? partial.maxTokens : undefined,
+});
+
+const migrateCommonSettings = (
+    partial: Partial<GeminiAgentSettings | OpenAIAgentSettings>,
+): Pick<
+    GeminiAgentSettings,
+    'generationStrategy' | 'confidenceSource' | 'traceCount' | 'deepConfEta' | 'tau' | 'groupWindow'
+> => ({
+    generationStrategy: VALID_GENERATION_STRATEGIES.includes(
+        partial.generationStrategy as GenerationStrategy,
+    )
+        ? (partial.generationStrategy as GenerationStrategy)
+        : 'single',
+    confidenceSource: 'judge',
+    traceCount:
+        typeof partial.traceCount === 'number' ? partial.traceCount : 8,
+    deepConfEta:
+        partial.deepConfEta === 10 || partial.deepConfEta === 90 ? partial.deepConfEta : 90,
+    tau: typeof partial.tau === 'number' ? partial.tau : 0.95,
+    groupWindow:
+        typeof partial.groupWindow === 'number' ? partial.groupWindow : 2048,
+});
+
+export const migrateAgentConfig = (
+    savedConfig: SavedAgentConfig,
+    expertList: Expert[],
+): AgentConfig | null => {
+    const expert = expertList.find((e) => e.id === savedConfig.expertId);
+    if (!expert) {
+        console.warn(`Expert with ID "${savedConfig.expertId}" not found. Skipping.`);
+        return null;
+    }
+
+    const baseConfig = {
+        id: crypto.randomUUID(),
+        expert,
+        status: 'PENDING' as const,
+    };
+
+    const provider = savedConfig.provider;
+
+    switch (provider) {
+        case 'gemini': {
+            const model: GeminiModel =
+                savedConfig.model === GEMINI_FLASH_MODEL ||
+                savedConfig.model === GEMINI_PRO_MODEL
+                    ? savedConfig.model
+                    : GEMINI_FLASH_MODEL;
+            const rawSettings =
+                savedConfig.settings &&
+                typeof savedConfig.settings === 'object'
+                    ? (savedConfig.settings as Partial<GeminiAgentSettings>)
+                    : {};
+            const effort: GeminiThinkingEffort = isGeminiThinkingEffort(rawSettings.effort)
+                ? rawSettings.effort
+                : 'dynamic';
+            const migratedSettings: GeminiAgentSettings = {
+                ...migrateCommonSettings(rawSettings),
+                effort,
+            };
+            return {
+                ...baseConfig,
+                model,
+                provider: 'gemini',
+                settings: migratedSettings,
+            } as GeminiAgentConfig;
+        }
+
+        case 'openai': {
+            const model: OpenAIModel =
+                savedConfig.model === OPENAI_AGENT_MODEL ||
+                savedConfig.model === OPENAI_GPT5_MINI_MODEL
+                    ? savedConfig.model
+                    : OPENAI_AGENT_MODEL;
+            const rawSettings =
+                savedConfig.settings &&
+                typeof savedConfig.settings === 'object'
+                    ? (savedConfig.settings as Partial<OpenAIAgentSettings>)
+                    : {};
+            const effort: OpenAIReasoningEffort = isOpenAIReasoningEffort(rawSettings.effort)
+                ? rawSettings.effort
+                : 'medium';
+            const verbosity: OpenAIVerbosity = isOpenAIVerbosity(rawSettings.verbosity)
+                ? rawSettings.verbosity
+                : 'medium';
+            const migratedSettings: OpenAIAgentSettings = {
+                ...migrateCommonSettings(rawSettings),
+                effort,
+                verbosity,
+            };
+            return {
+                ...baseConfig,
+                model,
+                provider: 'openai',
+                settings: migratedSettings,
+            } as OpenAIAgentConfig;
+        }
+
+        case 'openrouter': {
+            const model =
+                typeof savedConfig.model === 'string'
+                    ? savedConfig.model
+                    : OPENROUTER_GPT_4O;
+            const rawSettings =
+                savedConfig.settings &&
+                typeof savedConfig.settings === 'object'
+                    ? (savedConfig.settings as Partial<OpenRouterAgentSettings>)
+                    : {};
+            const migratedSettings = migrateOpenRouterSettings(rawSettings);
+            return {
+                ...baseConfig,
+                model,
+                provider: 'openrouter',
+                settings: migratedSettings,
+            } as OpenRouterAgentConfig;
+        }
+
+        default:
+            console.warn(
+                `Unknown provider "${provider}" for expert "${savedConfig.expertId}". Skipping.`,
+            );
+            return null;
+    }
+};
+

--- a/lib/sessionMigration.ts
+++ b/lib/sessionMigration.ts
@@ -109,6 +109,12 @@ export const migrateAgentConfig = (
     };
 
     const provider = savedConfig.provider;
+    const rawSettings =
+        savedConfig.settings && typeof savedConfig.settings === 'object'
+            ? (savedConfig.settings as Partial<
+                  GeminiAgentSettings | OpenAIAgentSettings | OpenRouterAgentSettings
+              >)
+            : {};
 
     switch (provider) {
         case 'gemini': {
@@ -117,16 +123,14 @@ export const migrateAgentConfig = (
                 savedConfig.model === GEMINI_PRO_MODEL
                     ? savedConfig.model
                     : GEMINI_FLASH_MODEL;
-            const rawSettings =
-                savedConfig.settings &&
-                typeof savedConfig.settings === 'object'
-                    ? (savedConfig.settings as Partial<GeminiAgentSettings>)
-                    : {};
-            const effort: GeminiThinkingEffort = isGeminiThinkingEffort(rawSettings.effort)
-                ? rawSettings.effort
+            const geminiSettings = rawSettings as Partial<GeminiAgentSettings>;
+            const effort: GeminiThinkingEffort = isGeminiThinkingEffort(
+                geminiSettings.effort,
+            )
+                ? geminiSettings.effort!
                 : 'dynamic';
             const migratedSettings: GeminiAgentSettings = {
-                ...migrateCommonSettings(rawSettings),
+                ...migrateCommonSettings(geminiSettings),
                 effort,
             };
             return {
@@ -143,19 +147,19 @@ export const migrateAgentConfig = (
                 savedConfig.model === OPENAI_GPT5_MINI_MODEL
                     ? savedConfig.model
                     : OPENAI_AGENT_MODEL;
-            const rawSettings =
-                savedConfig.settings &&
-                typeof savedConfig.settings === 'object'
-                    ? (savedConfig.settings as Partial<OpenAIAgentSettings>)
-                    : {};
-            const effort: OpenAIReasoningEffort = isOpenAIReasoningEffort(rawSettings.effort)
-                ? rawSettings.effort
+            const openAISettings = rawSettings as Partial<OpenAIAgentSettings>;
+            const effort: OpenAIReasoningEffort = isOpenAIReasoningEffort(
+                openAISettings.effort,
+            )
+                ? openAISettings.effort!
                 : 'medium';
-            const verbosity: OpenAIVerbosity = isOpenAIVerbosity(rawSettings.verbosity)
-                ? rawSettings.verbosity
+            const verbosity: OpenAIVerbosity = isOpenAIVerbosity(
+                openAISettings.verbosity,
+            )
+                ? openAISettings.verbosity!
                 : 'medium';
             const migratedSettings: OpenAIAgentSettings = {
-                ...migrateCommonSettings(rawSettings),
+                ...migrateCommonSettings(openAISettings),
                 effort,
                 verbosity,
             };
@@ -172,12 +176,9 @@ export const migrateAgentConfig = (
                 typeof savedConfig.model === 'string'
                     ? savedConfig.model
                     : OPENROUTER_GPT_4O;
-            const rawSettings =
-                savedConfig.settings &&
-                typeof savedConfig.settings === 'object'
-                    ? (savedConfig.settings as Partial<OpenRouterAgentSettings>)
-                    : {};
-            const migratedSettings = migrateOpenRouterSettings(rawSettings);
+            const openRouterSettings =
+                rawSettings as Partial<OpenRouterAgentSettings>;
+            const migratedSettings = migrateOpenRouterSettings(openRouterSettings);
             return {
                 ...baseConfig,
                 model,

--- a/moe/arbiter.ts
+++ b/moe/arbiter.ts
@@ -133,8 +133,17 @@ export const arbitrateStream = async (
         const model = arbiterModel;
 
         try {
+            const completionParams: OpenAI.Chat.ChatCompletionCreateParamsStreaming & {
+                reasoning?: { effort: OpenAIReasoningEffort };
+            } = {
+                model,
+                messages,
+                stream: true,
+                reasoning: { effort: openAIArbiterEffort },
+            };
+
             const stream = await callWithRetry(
-                () => openaiAI.chat.completions.create({ model, messages, stream: true, reasoning: { effort: openAIArbiterEffort } }),
+                () => openaiAI.chat.completions.create(completionParams),
                 'OpenAI'
             );
 


### PR DESCRIPTION
## Summary
- pull session migration logic out of `App.tsx` into `lib/sessionMigration.ts`
- import and use `migrateAgentConfig` from the new module

## Testing
- `npm test`
- `npm run build` *(fails: object literal may only specify known properties and other TS errors in moe/arbiter.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b362e120388322baf3d168486a9e29