### PR TITLE
fix: allow optional fields in saved agent config

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ import {
     GeminiThinkingEffort,
     RunStatus,
     OpenAIReasoningEffort,
+    SavedAgentConfigSchema,
 } from '@/types';
 import {
     GEMINI_PRO_MODEL,
@@ -69,13 +70,6 @@ const OPENAI_API_KEY_STORAGE_KEY = 'openai_api_key';
 const GEMINI_API_KEY_STORAGE_KEY = 'gemini_api_key';
 const OPENROUTER_API_KEY_STORAGE_KEY = 'openrouter_api_key';
 const MAX_HISTORY_LENGTH = 20;
-
-const SavedAgentConfigSchema = z.object({
-    expertId: z.string().optional(),
-    model: z.string().optional(),
-    provider: z.enum(['gemini', 'openai', 'openrouter']).optional(),
-    settings: z.record(z.unknown()).optional().default({}),
-});
 
 const SessionDataSchema = z.object({
     version: z.number().default(0),
@@ -783,11 +777,8 @@ const App: React.FC = () => {
                     }
 
                     const loadedAgentConfigs: AgentConfig[] = data.agentConfigs
-                        .map((savedConfig: z.infer<typeof SavedAgentConfigSchema>) =>
-                            migrateAgentConfig(
-                                savedConfig as unknown as SavedAgentConfig,
-                                experts,
-                            ),
+                        .map((savedConfig) =>
+                            migrateAgentConfig(savedConfig, experts),
                         )
                         .filter(
                             (config: AgentConfig | null): config is AgentConfig =>

--- a/App.tsx
+++ b/App.tsx
@@ -761,7 +761,7 @@ const App: React.FC = () => {
                     if (!result.success) {
                         const formatted = result.error.errors
                             .map(
-                                (err) =>
+                                (err: z.ZodIssue) =>
                                     `${err.path.join('.') || '(root)'} - ${err.message}`,
                             )
                             .join('; ');
@@ -783,8 +783,16 @@ const App: React.FC = () => {
                     }
 
                     const loadedAgentConfigs: AgentConfig[] = data.agentConfigs
-                        .map((savedConfig) => migrateAgentConfig(savedConfig, experts))
-                        .filter((config): config is AgentConfig => config !== null);
+                        .map((savedConfig: z.infer<typeof SavedAgentConfigSchema>) =>
+                            migrateAgentConfig(
+                                savedConfig as unknown as SavedAgentConfig,
+                                experts,
+                            ),
+                        )
+                        .filter(
+                            (config: AgentConfig | null): config is AgentConfig =>
+                                config !== null,
+                        );
 
                     handleNewRun(); // Clear current state before loading
                     setPrompt(data.prompt);

--- a/App.tsx
+++ b/App.tsx
@@ -703,7 +703,7 @@ const App: React.FC = () => {
                 expertId: config.expert.id,
                 model: config.model,
                 provider: config.provider,
-                settings: config.settings,
+                settings: config.settings as unknown as Record<string, unknown>,
             }));
 
             const sessionData: SessionData = {
@@ -777,7 +777,7 @@ const App: React.FC = () => {
                     }
 
                     const loadedAgentConfigs: AgentConfig[] = data.agentConfigs
-                        .map((savedConfig) =>
+                        .map((savedConfig: SavedAgentConfig) =>
                             migrateAgentConfig(savedConfig, experts),
                         )
                         .filter(

--- a/App.tsx
+++ b/App.tsx
@@ -705,7 +705,7 @@ const App: React.FC = () => {
                     expertId: config.expert.id,
                     model: config.model,
                     provider: config.provider,
-                    settings: config.settings as unknown as SavedAgentSettings,
+                    settings: config.settings as SavedAgentSettings,
                 }),
             );
 

--- a/App.tsx
+++ b/App.tsx
@@ -21,6 +21,7 @@ import {
     RunStatus,
     OpenAIReasoningEffort,
     SavedAgentConfigSchema,
+    SavedAgentSettings,
 } from '@/types';
 import {
     GEMINI_PRO_MODEL,
@@ -699,12 +700,14 @@ const App: React.FC = () => {
 
     const handleSaveSession = useCallback(() => {
         try {
-            const savedAgentConfigs: SavedAgentConfig[] = agentConfigs.map(config => ({
-                expertId: config.expert.id,
-                model: config.model,
-                provider: config.provider,
-                settings: config.settings,
-            }));
+            const savedAgentConfigs: SavedAgentConfig[] = agentConfigs.map(
+                (config) => ({
+                    expertId: config.expert.id,
+                    model: config.model,
+                    provider: config.provider,
+                    settings: config.settings as unknown as SavedAgentSettings,
+                }),
+            );
 
             const sessionData: SessionData = {
                 version: SESSION_DATA_VERSION,

--- a/App.tsx
+++ b/App.tsx
@@ -703,7 +703,7 @@ const App: React.FC = () => {
                 expertId: config.expert.id,
                 model: config.model,
                 provider: config.provider,
-                settings: config.settings as unknown as Record<string, unknown>,
+                settings: config.settings,
             }));
 
             const sessionData: SessionData = {

--- a/lib/sessionMigration.ts
+++ b/lib/sessionMigration.ts
@@ -7,6 +7,7 @@ import {
     OpenAIAgentSettings,
     OpenRouterAgentSettings,
     SavedAgentConfig,
+    SavedAgentSettings,
     GeminiThinkingEffort,
     OpenAIReasoningEffort,
     OpenAIVerbosity,
@@ -119,11 +120,9 @@ export const migrateAgentConfig = (
     };
 
     const provider = savedConfig.provider;
-    const rawSettings =
+    const rawSettings: SavedAgentSettings =
         savedConfig.settings && typeof savedConfig.settings === 'object'
-            ? (savedConfig.settings as Partial<
-                  GeminiAgentSettings | OpenAIAgentSettings | OpenRouterAgentSettings
-              >)
+            ? savedConfig.settings
             : {};
 
     switch (provider) {

--- a/types.ts
+++ b/types.ts
@@ -115,7 +115,7 @@ export interface SavedAgentConfig {
     expertId?: string;
     model?: AgentModel;
     provider?: ApiProvider;
-    settings: GeminiAgentSettings | OpenAIAgentSettings | OpenRouterAgentSettings | Record<string, unknown>;
+    settings: GeminiAgentSettings | OpenAIAgentSettings | OpenRouterAgentSettings;
 }
 
 export const SESSION_DATA_VERSION = 2;

--- a/types.ts
+++ b/types.ts
@@ -73,8 +73,7 @@ export interface OpenRouterAgentSettings {
     maxTokens?: number;
 }
 
-const GeminiAgentSettingsSchema: z.ZodType<Partial<GeminiAgentSettings>> = z.object({
-    effort: z.enum(['dynamic', 'high', 'medium', 'low', 'none']).optional(),
+const CommonAgentSettingsSchema = z.object({
     generationStrategy: z
         .enum(['single', 'deepconf-offline', 'deepconf-online'])
         .optional(),
@@ -85,18 +84,16 @@ const GeminiAgentSettingsSchema: z.ZodType<Partial<GeminiAgentSettings>> = z.obj
     groupWindow: z.number().optional(),
 });
 
-const OpenAIAgentSettingsSchema: z.ZodType<Partial<OpenAIAgentSettings>> = z.object({
-    effort: z.enum(['medium', 'high']).optional(),
-    verbosity: z.enum(['low', 'medium', 'high']).optional(),
-    generationStrategy: z
-        .enum(['single', 'deepconf-offline', 'deepconf-online'])
-        .optional(),
-    confidenceSource: z.literal('judge').optional(),
-    traceCount: z.number().optional(),
-    deepConfEta: z.union([z.literal(10), z.literal(90)]).optional(),
-    tau: z.number().optional(),
-    groupWindow: z.number().optional(),
-});
+const GeminiAgentSettingsSchema: z.ZodType<Partial<GeminiAgentSettings>> =
+    CommonAgentSettingsSchema.extend({
+        effort: z.enum(['dynamic', 'high', 'medium', 'low', 'none']).optional(),
+    });
+
+const OpenAIAgentSettingsSchema: z.ZodType<Partial<OpenAIAgentSettings>> =
+    CommonAgentSettingsSchema.extend({
+        effort: z.enum(['medium', 'high']).optional(),
+        verbosity: z.enum(['low', 'medium', 'high']).optional(),
+    });
 
 const OpenRouterAgentSettingsSchema: z.ZodType<Partial<OpenRouterAgentSettings>> = z.object({
     temperature: z.number().optional(),

--- a/types.ts
+++ b/types.ts
@@ -154,6 +154,25 @@ export const SavedAgentConfigSchema = z.object({
             OpenRouterAgentSettingsSchema,
         ])
         .optional(),
+}).superRefine((config, ctx) => {
+    if (!config.provider || !config.settings) return;
+
+    const schema =
+        config.provider === 'gemini'
+            ? GeminiAgentSettingsSchema
+            : config.provider === 'openai'
+            ? OpenAIAgentSettingsSchema
+            : OpenRouterAgentSettingsSchema;
+
+    const result = schema.safeParse(config.settings);
+    if (!result.success) {
+        for (const issue of result.error.issues) {
+            ctx.addIssue({
+                ...issue,
+                path: ['settings', ...issue.path],
+            });
+        }
+    }
 });
 export type SavedAgentConfig = z.infer<typeof SavedAgentConfigSchema>;
 

--- a/types.ts
+++ b/types.ts
@@ -82,18 +82,18 @@ const CommonAgentSettingsSchema = z.object({
     deepConfEta: z.union([z.literal(10), z.literal(90)]).optional(),
     tau: z.number().optional(),
     groupWindow: z.number().optional(),
-});
+}).strict();
 
 const GeminiAgentSettingsSchema: z.ZodType<Partial<GeminiAgentSettings>> =
     CommonAgentSettingsSchema.extend({
         effort: z.enum(['dynamic', 'high', 'medium', 'low', 'none']).optional(),
-    });
+    }).strict();
 
 const OpenAIAgentSettingsSchema: z.ZodType<Partial<OpenAIAgentSettings>> =
     CommonAgentSettingsSchema.extend({
         effort: z.enum(['medium', 'high']).optional(),
         verbosity: z.enum(['low', 'medium', 'high']).optional(),
-    });
+    }).strict();
 
 const OpenRouterAgentSettingsSchema: z.ZodType<Partial<OpenRouterAgentSettings>> = z.object({
     temperature: z.number().optional(),
@@ -103,7 +103,7 @@ const OpenRouterAgentSettingsSchema: z.ZodType<Partial<OpenRouterAgentSettings>>
     presencePenalty: z.number().optional(),
     repetitionPenalty: z.number().optional(),
     maxTokens: z.number().optional(),
-});
+}).strict();
 
 export interface BaseAgentConfig {
     id: string; // unique instance id

--- a/types.ts
+++ b/types.ts
@@ -111,11 +111,7 @@ const ProviderSettingsSchemaMap: Record<ApiProvider, z.ZodTypeAny> = {
     openrouter: OpenRouterAgentSettingsSchema,
 };
 
-export type SavedAgentSettings =
-    | Partial<GeminiAgentSettings>
-    | Partial<OpenAIAgentSettings>
-    | Partial<OpenRouterAgentSettings>
-    | Record<string, unknown>;
+export type SavedAgentSettings = Record<string, unknown>;
 
 const SavedAgentSettingsSchema: z.ZodType<SavedAgentSettings> =
     z.record(z.unknown());
@@ -166,7 +162,10 @@ const SavedAgentConfigSchemaBase = z.object({
 });
 
 export const SavedAgentConfigSchema = SavedAgentConfigSchemaBase.superRefine(
-    (config: z.infer<typeof SavedAgentConfigSchemaBase>, ctx) => {
+    (
+        config: z.infer<typeof SavedAgentConfigSchemaBase>,
+        ctx: z.RefinementCtx,
+    ) => {
         if (!config.provider || !config.settings) return;
 
         const schema = ProviderSettingsSchemaMap[config.provider];

--- a/types.ts
+++ b/types.ts
@@ -111,6 +111,15 @@ const ProviderSettingsSchemaMap: Record<ApiProvider, z.ZodTypeAny> = {
     openrouter: OpenRouterAgentSettingsSchema,
 };
 
+type SavedAgentSettings =
+    | GeminiAgentSettings
+    | OpenAIAgentSettings
+    | OpenRouterAgentSettings
+    | Record<string, unknown>;
+
+const SavedAgentSettingsSchema: z.ZodType<SavedAgentSettings> =
+    z.record(z.unknown());
+
 export interface BaseAgentConfig {
     id: string; // unique instance id
     expert: Expert;
@@ -153,7 +162,7 @@ export const SavedAgentConfigSchema = z.object({
     expertId: z.string().optional(),
     model: z.string().optional(),
     provider: z.enum(['gemini', 'openai', 'openrouter']).optional(),
-    settings: z.record(z.unknown()).optional(),
+    settings: SavedAgentSettingsSchema.optional(),
 }).superRefine((config, ctx) => {
     if (!config.provider || !config.settings) return;
 

--- a/types.ts
+++ b/types.ts
@@ -5,6 +5,7 @@ import {
     OPENAI_GPT5_MINI_MODEL,
     OPENAI_ARBITER_MODEL,
 } from './constants';
+import { z } from 'zod';
 
 export type ApiProvider = 'gemini' | 'openai' | 'openrouter';
 export type AgentStatus = 'PENDING' | 'RUNNING' | 'COMPLETED' | 'FAILED' | 'QUEUED';
@@ -72,6 +73,40 @@ export interface OpenRouterAgentSettings {
     maxTokens?: number;
 }
 
+const GeminiAgentSettingsSchema: z.ZodType<Partial<GeminiAgentSettings>> = z.object({
+    effort: z.enum(['dynamic', 'high', 'medium', 'low', 'none']).optional(),
+    generationStrategy: z
+        .enum(['single', 'deepconf-offline', 'deepconf-online'])
+        .optional(),
+    confidenceSource: z.literal('judge').optional(),
+    traceCount: z.number().optional(),
+    deepConfEta: z.union([z.literal(10), z.literal(90)]).optional(),
+    tau: z.number().optional(),
+    groupWindow: z.number().optional(),
+});
+
+const OpenAIAgentSettingsSchema: z.ZodType<Partial<OpenAIAgentSettings>> = z.object({
+    effort: z.enum(['medium', 'high']).optional(),
+    verbosity: z.enum(['low', 'medium', 'high']).optional(),
+    generationStrategy: z
+        .enum(['single', 'deepconf-offline', 'deepconf-online'])
+        .optional(),
+    confidenceSource: z.literal('judge').optional(),
+    traceCount: z.number().optional(),
+    deepConfEta: z.union([z.literal(10), z.literal(90)]).optional(),
+    tau: z.number().optional(),
+    groupWindow: z.number().optional(),
+});
+
+const OpenRouterAgentSettingsSchema: z.ZodType<Partial<OpenRouterAgentSettings>> = z.object({
+    temperature: z.number().optional(),
+    topP: z.number().optional(),
+    topK: z.number().optional(),
+    frequencyPenalty: z.number().optional(),
+    presencePenalty: z.number().optional(),
+    repetitionPenalty: z.number().optional(),
+    maxTokens: z.number().optional(),
+});
 
 export interface BaseAgentConfig {
     id: string; // unique instance id
@@ -111,12 +146,19 @@ export type ArbiterModel =
 export type OpenAIVerbosity = 'low' | 'medium' | 'high';
 export type OpenAIReasoningEffort = 'medium' | 'high';
 
-export interface SavedAgentConfig {
-    expertId?: string;
-    model?: AgentModel;
-    provider?: ApiProvider;
-    settings: GeminiAgentSettings | OpenAIAgentSettings | OpenRouterAgentSettings;
-}
+export const SavedAgentConfigSchema = z.object({
+    expertId: z.string().optional(),
+    model: z.string().optional(),
+    provider: z.enum(['gemini', 'openai', 'openrouter']).optional(),
+    settings: z
+        .union([
+            GeminiAgentSettingsSchema,
+            OpenAIAgentSettingsSchema,
+            OpenRouterAgentSettingsSchema,
+        ])
+        .optional(),
+});
+export type SavedAgentConfig = z.infer<typeof SavedAgentConfigSchema>;
 
 export const SESSION_DATA_VERSION = 2;
 

--- a/types.ts
+++ b/types.ts
@@ -112,10 +112,10 @@ export type OpenAIVerbosity = 'low' | 'medium' | 'high';
 export type OpenAIReasoningEffort = 'medium' | 'high';
 
 export interface SavedAgentConfig {
-    expertId: string;
-    model: AgentModel;
-    provider: ApiProvider;
-    settings: GeminiAgentSettings | OpenAIAgentSettings | OpenRouterAgentSettings;
+    expertId?: string;
+    model?: AgentModel;
+    provider?: ApiProvider;
+    settings: GeminiAgentSettings | OpenAIAgentSettings | OpenRouterAgentSettings | Record<string, unknown>;
 }
 
 export const SESSION_DATA_VERSION = 2;


### PR DESCRIPTION
## Summary
- allow missing `expertId`, `model`, and `provider` in `SavedAgentConfig`
- accept generic record for `settings`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b376e048588322ae13ed0d0f3a80db