### PR TITLE
fix: ensure agent settings match SavedAgentSettings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,7 +21,6 @@ import {
     RunStatus,
     OpenAIReasoningEffort,
     SavedAgentConfigSchema,
-    SavedAgentSettings,
 } from '@/types';
 import {
     GEMINI_PRO_MODEL,
@@ -705,7 +704,7 @@ const App: React.FC = () => {
                     expertId: config.expert.id,
                     model: config.model,
                     provider: config.provider,
-                    settings: config.settings as SavedAgentSettings,
+                    settings: { ...config.settings },
                 }),
             );
 

--- a/types.ts
+++ b/types.ts
@@ -43,7 +43,6 @@ export type GeminiThinkingEffort = 'dynamic' | 'high' | 'medium' | 'low' | 'none
 export type GenerationStrategy = 'single' | 'deepconf-offline' | 'deepconf-online';
 
 export interface GeminiAgentSettings {
-    [key: string]: unknown;
     effort: GeminiThinkingEffort;
     generationStrategy: GenerationStrategy;
     confidenceSource: 'judge';
@@ -54,7 +53,6 @@ export interface GeminiAgentSettings {
 }
 
 export interface OpenAIAgentSettings {
-    [key: string]: unknown;
     effort: 'medium' | 'high';
     verbosity: 'low' | 'medium' | 'high';
     generationStrategy: GenerationStrategy;
@@ -66,7 +64,6 @@ export interface OpenAIAgentSettings {
 }
 
 export interface OpenRouterAgentSettings {
-    [key: string]: unknown;
     temperature: number;
     topP: number;
     topK: number;

--- a/types.ts
+++ b/types.ts
@@ -43,6 +43,7 @@ export type GeminiThinkingEffort = 'dynamic' | 'high' | 'medium' | 'low' | 'none
 export type GenerationStrategy = 'single' | 'deepconf-offline' | 'deepconf-online';
 
 export interface GeminiAgentSettings {
+    [key: string]: unknown;
     effort: GeminiThinkingEffort;
     generationStrategy: GenerationStrategy;
     confidenceSource: 'judge';
@@ -53,6 +54,7 @@ export interface GeminiAgentSettings {
 }
 
 export interface OpenAIAgentSettings {
+    [key: string]: unknown;
     effort: 'medium' | 'high';
     verbosity: 'low' | 'medium' | 'high';
     generationStrategy: GenerationStrategy;
@@ -64,6 +66,7 @@ export interface OpenAIAgentSettings {
 }
 
 export interface OpenRouterAgentSettings {
+    [key: string]: unknown;
     temperature: number;
     topP: number;
     topK: number;


### PR DESCRIPTION
## Summary
- add index signatures to GeminiAgentSettings, OpenAIAgentSettings, and OpenRouterAgentSettings so they can be treated as SavedAgentSettings

## Testing
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b39fd6db5c8322ad0af8409d182697