### PR TITLE
feat: improve Gemini retry handling

### DIFF
--- a/moe/arbiter.ts
+++ b/moe/arbiter.ts
@@ -173,13 +173,14 @@ export const arbitrateStream = async (
 
     const geminiAI = getGeminiClient();
     try {
-        const stream = await callWithGeminiRetry(() =>
+        const stream = await callWithGeminiRetry((signal) =>
             geminiAI.models.generateContentStream({
                 model,
                 contents: { parts: [{ text: arbiterPrompt }] },
                 config: {
                     systemInstruction: ARBITER_PERSONA,
                     thinkingConfig: { thinkingBudget: budget },
+                    abortSignal: signal,
                 }
             })
         );

--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -29,6 +29,10 @@ const GEMINI_FLASH_BUDGETS: Record<Extract<GeminiThinkingEffort, 'none' | 'low' 
     dynamic: -1,
 };
 
+const GEMINI_RETRY_COUNT = Number(process.env.GEMINI_RETRY_COUNT ?? '3');
+const GEMINI_BACKOFF_MS = Number(process.env.GEMINI_BACKOFF_MS ?? '1000');
+const GEMINI_TIMEOUT_MS = Number(process.env.GEMINI_TIMEOUT_MS ?? '10000');
+
 const runExpertGeminiSingle = async (
     expert: ExpertDispatch,
     prompt: string,
@@ -68,15 +72,38 @@ const runExpertGeminiSingle = async (
         if (generateContentParams.config) generateContentParams.config.thinkingConfig = { thinkingBudget: budget };
     }
 
-    if (abortSignal && generateContentParams.config) {
-        generateContentParams.config.abortSignal = abortSignal;
-    }
-
     const geminiAI = getGeminiClient();
     try {
-        const response = await callWithGeminiRetry(() => geminiAI.models.generateContent(generateContentParams));
+        const response = await callWithGeminiRetry(
+            (signal) => {
+                let finalSignal: AbortSignal = signal;
+                let onAbort: (() => void) | undefined;
+                if (abortSignal) {
+                    const controller = new AbortController();
+                    onAbort = () => controller.abort();
+                    abortSignal.addEventListener('abort', onAbort);
+                    signal.addEventListener('abort', onAbort);
+                    finalSignal = controller.signal;
+                }
+                if (generateContentParams.config) {
+                    generateContentParams.config.abortSignal = finalSignal;
+                }
+                const promise = geminiAI.models.generateContent(generateContentParams);
+                if (abortSignal && onAbort) {
+                    return promise.finally(() => {
+                        abortSignal.removeEventListener('abort', onAbort);
+                        signal.removeEventListener('abort', onAbort);
+                    });
+                }
+                return promise;
+            },
+            { retries: GEMINI_RETRY_COUNT, baseDelayMs: GEMINI_BACKOFF_MS, timeoutMs: GEMINI_TIMEOUT_MS }
+        );
         return getGeminiResponseText(response);
     } catch (error) {
+        if (error instanceof Error && error.message === 'Gemini request timed out') {
+            throw error;
+        }
         return handleGeminiError(error, 'dispatcher', 'dispatch');
     }
 }

--- a/services/deepconf.ts
+++ b/services/deepconf.ts
@@ -108,7 +108,7 @@ export const judgeAnswer = async (prompt: string, answer: string, agentModel: st
         const judgeModel = agentModel === GEMINI_PRO_MODEL ? GEMINI_PRO_MODEL : GEMINI_FLASH_MODEL;
         
         const geminiAI = getGeminiClient();
-        const response = await callWithGeminiRetry(() =>
+        const response = await callWithGeminiRetry((signal) =>
             geminiAI.models.generateContent({
                 model: judgeModel,
                 contents: { parts: [{ text: judgeUserTemplate(prompt, answer) }] },
@@ -127,6 +127,7 @@ export const judgeAnswer = async (prompt: string, answer: string, agentModel: st
                         propertyOrdering: ["score", "reasons"],
                     },
                     temperature: 0, // deterministic judging
+                    abortSignal: signal,
                 },
             })
         );

--- a/services/geminiUtils.ts
+++ b/services/geminiUtils.ts
@@ -22,26 +22,43 @@ export const isGeminiServerError = (error: unknown): boolean => {
     return typeof status === 'number' && status >= 500;
 };
 
+export interface GeminiRetryOpts {
+    retries?: number;
+    baseDelayMs?: number;
+    timeoutMs?: number;
+}
+
 export const callWithGeminiRetry = async <T>(
-    fn: () => Promise<T>,
-    retries = 3,
-    baseDelayMs = 1000,
+    fn: (signal: AbortSignal) => Promise<T>,
+    { retries = 3, baseDelayMs = 1000, timeoutMs = 10000 }: GeminiRetryOpts = {}
 ): Promise<T> => {
     for (let attempt = 0; ; attempt++) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeoutMs);
         try {
-            return await fn();
+            return await fn(controller.signal);
         } catch (error) {
             if ((isGeminiRateLimitError(error) || isGeminiServerError(error)) && attempt < retries) {
                 await sleep(baseDelayMs * Math.pow(2, attempt));
                 continue;
             }
+            if (error instanceof Error && error.name === 'AbortError') {
+                throw new Error('Gemini request timed out');
+            }
             if (isGeminiRateLimitError(error)) {
                 throw new Error(GEMINI_QUOTA_MESSAGE);
             }
             if (isGeminiServerError(error)) {
+                const maybe = error as { status?: number; response?: { status?: number } };
+                const status = maybe.status ?? maybe.response?.status;
+                if (status === 503) {
+                    throw new Error('Gemini service responded with 503 Service Unavailable after retries.');
+                }
                 throw new Error('Gemini service is temporarily unavailable. Please try again later.');
             }
             throw error;
+        } finally {
+            clearTimeout(timer);
         }
     }
 };

--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ExpertDispatch } from '@/moe/types';
+import { GEMINI_FLASH_MODEL } from '@/constants';
+import type { GeminiAgentConfig } from '@/types';
+import { getGeminiClient } from '@/services/llmService';
+
+vi.mock('@/services/llmService', () => ({
+  getGeminiClient: vi.fn(),
+  getOpenAIClient: vi.fn(),
+  getOpenRouterApiKey: vi.fn(),
+  callWithRetry: vi.fn(),
+  fetchWithRetry: vi.fn(),
+}));
+
+describe('dispatcher Gemini failure handling', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    process.env.GEMINI_RETRY_COUNT = '0';
+    process.env.GEMINI_BACKOFF_MS = '1';
+  });
+
+  afterEach(() => {
+    delete process.env.GEMINI_RETRY_COUNT;
+    delete process.env.GEMINI_BACKOFF_MS;
+  });
+
+  it('records a failed draft when Gemini returns 503 and continues with others', async () => {
+    const generateContent = vi
+      .fn()
+      .mockRejectedValueOnce({ status: 503 })
+      .mockResolvedValueOnce({ text: () => 'ok' });
+
+    (getGeminiClient as unknown as vi.Mock).mockReturnValue({
+      models: { generateContent },
+    });
+    const { dispatch } = await import('@/moe/dispatcher');
+
+    const experts: ExpertDispatch[] = [
+      { agentId: 'fail', provider: 'gemini', model: GEMINI_FLASH_MODEL, id: '1', name: 'fail', persona: '' },
+      { agentId: 'ok', provider: 'gemini', model: GEMINI_FLASH_MODEL, id: '2', name: 'ok', persona: '' },
+    ];
+
+    const baseConfig = {
+      provider: 'gemini',
+      model: GEMINI_FLASH_MODEL,
+      status: 'PENDING',
+      settings: {
+        effort: 'low',
+        generationStrategy: 'single',
+        confidenceSource: 'judge',
+        traceCount: 1,
+        deepConfEta: 90,
+        tau: 0.95,
+        groupWindow: 2048,
+      },
+    } as const;
+
+    const configs: GeminiAgentConfig[] = [
+      { ...baseConfig, id: 'fail', expert: experts[0] },
+      { ...baseConfig, id: 'ok', expert: experts[1] },
+    ];
+
+    const drafts = await dispatch(experts, 'prompt', [], configs, () => {});
+
+    const failDraft = drafts.find(d => d.agentId === 'fail');
+    const okDraft = drafts.find(d => d.agentId === 'ok');
+
+    expect(failDraft?.status).toBe('FAILED');
+    expect(okDraft?.status).toBe('COMPLETED');
+    expect(okDraft?.content).toBe('ok');
+  });
+});


### PR DESCRIPTION
## Summary
- add abortable timeout, configurable retries, and clearer 503 errors for Gemini calls
- allow dispatcher to tune retry/backoff and fail fast on Gemini timeouts
- test dispatcher continues processing when a Gemini agent returns 503

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b3a9ebd7848322987565857df6cc69