### PR TITLE
fix: use Vitest Mock type in dispatcher test

### DIFF
--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
 import { ExpertDispatch } from '@/moe/types';
 import { GEMINI_FLASH_MODEL } from '@/constants';
 import type { GeminiAgentConfig } from '@/types';
@@ -31,7 +32,7 @@ describe('dispatcher Gemini failure handling', () => {
       .mockRejectedValueOnce({ status: 503 })
       .mockResolvedValueOnce({ text: () => 'ok' });
 
-    (getGeminiClient as unknown as vi.Mock).mockReturnValue({
+    (getGeminiClient as unknown as Mock).mockReturnValue({
       models: { generateContent },
     });
     const { dispatch } = await import('@/moe/dispatcher');


### PR DESCRIPTION
## Summary
- import Vitest's Mock type
- cast `getGeminiClient` to `Mock` instead of `vi.Mock`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3bcb68a408322b1e57bafbd985fd9