### PR TITLE
fix: allow callWithRetry to accept sync stream factories

### DIFF
--- a/services/llmService.ts
+++ b/services/llmService.ts
@@ -46,8 +46,9 @@ export const fetchWithRetry = async (
     throw new Error("fetchWithRetry exhausted all retries without success.");
 };
 
+// callWithRetry now accepts functions that may return a promise or a synchronous value.
 export const callWithRetry = async <T>(
-    fn: () => Promise<T>,
+    fn: () => Promise<T> | T,
     serviceName: string,
     retries = 3,
     baseDelayMs = 500,


### PR DESCRIPTION
## Summary
- permit callWithRetry to handle functions that return synchronous values or promises

## Testing
- `npm test`
- `npm run build` *(fails: Could not load @dqbd/tiktoken wasm - ESM integration proposal for Wasm is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cfb1915c83229ba2a6d6b2a53fd0