### PR TITLE
Use tiktoken lite WASM for browser-safe token counts

### DIFF
--- a/moe/orchestrator.ts
+++ b/moe/orchestrator.ts
@@ -6,7 +6,7 @@ import { arbitrateStream } from './arbiter';
 import { Draft, ExpertDispatch } from './types';
 import { GEMINI_PRO_MODEL } from '@/constants';
 import { AgentConfig, GeminiThinkingEffort, ImageState, OpenAIReasoningEffort } from '@/types';
-import { init, Tiktoken } from '@dqbd/tiktoken/lite/init';
+import type { Tiktoken } from '@dqbd/tiktoken/lite/init';
 import wasm from '@dqbd/tiktoken/lite/tiktoken_bg.wasm?url';
 import model from '@dqbd/tiktoken/encoders/cl100k_base.json';
 
@@ -30,7 +30,8 @@ let encoderPromise: Promise<Tiktoken> | null = null;
 const loadEncoder = () => {
     if (!encoderPromise) {
         encoderPromise = (async () => {
-            await init(async (imports: WebAssembly.Imports) => {
+            const { default: init, Tiktoken } = await import('@dqbd/tiktoken/lite/init');
+            await (init as unknown as (cb: (imports: WebAssembly.Imports) => Promise<any>) => Promise<any>)(async (imports: WebAssembly.Imports) => {
                 const response = await fetch(wasm);
                 const bytes = await response.arrayBuffer();
                 return WebAssembly.instantiate(bytes, imports);


### PR DESCRIPTION
## Summary
- Switch orchestrator token estimator to `@dqbd/tiktoken/lite` WASM build
- Lazily initialize tiktoken encoder in the browser
- Import tiktoken's WASM initializer as a default export at runtime so encoder loads correctly

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3dd33f72883229f0960de874590e2