### PR TITLE
Expose orchestrator abort handle earlier

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -425,7 +425,7 @@ const App: React.FC = () => {
                 ));
             };
 
-            const { stream, switchedArbiter, abort } = await runOrchestration({
+            const { promise, abort } = runOrchestration({
                 prompt: finalPrompt,
                 images,
                 agentConfigs,
@@ -435,7 +435,9 @@ const App: React.FC = () => {
                 geminiArbiterEffort
             }, { onInitialAgents, onDraftComplete: onDraftUpdate });
             orchestratorAbortRef.current = abort;
-            
+
+            const { stream, switchedArbiter } = await promise;
+
             if (switchedArbiter) {
                 setArbiterSwitchWarning('The selected GPT-5 arbiter was automatically switched to Gemini 2.5 Pro due to a large input size to prevent errors. Gemini models support larger context windows.');
             }


### PR DESCRIPTION
## Summary
- restructure `runOrchestration` to return a promise and abort handle immediately
- adjust orchestration caller to await the promise after storing abort

## Testing
- `npm test` *(fails: Gemini service responded with 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f7165e24832297f8c9921b7ea1c5