### PR TITLE
fix: improve abort handling and prompt input

### DIFF
--- a/components/PromptInput.tsx
+++ b/components/PromptInput.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useEffect, useMemo } from 'react';
+import React, { useCallback, useRef, useEffect, useMemo, useState } from 'react';
 import {
     XCircleIcon,
     PlusIcon,
@@ -49,7 +49,13 @@ const PromptInput: React.FC<PromptInputProps> = ({
 }) => {
     const fileInputRef = useRef<HTMLInputElement>(null);
     const textareaRef = inputRef || useRef<HTMLTextAreaElement>(null);
-    const MAX_TEXTAREA_HEIGHT = useMemo(() => Math.min(200, window.innerHeight * 0.25), []);
+    const [maxTextareaHeight, setMaxTextareaHeight] = useState(() => Math.min(200, window.innerHeight * 0.25));
+
+    useEffect(() => {
+        const handleResize = () => setMaxTextareaHeight(Math.min(200, window.innerHeight * 0.25));
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
 
     const handleFileChange = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
         const files = event.target.files;
@@ -137,9 +143,9 @@ const PromptInput: React.FC<PromptInputProps> = ({
             textareaRef.current.style.height = 'auto';
             const scrollHeight = textareaRef.current.scrollHeight;
 
-            if (scrollHeight > MAX_TEXTAREA_HEIGHT) {
+            if (scrollHeight > maxTextareaHeight) {
                 // If content is too tall, set to max height and enable scrolling
-                textareaRef.current.style.height = `${MAX_TEXTAREA_HEIGHT}px`;
+                textareaRef.current.style.height = `${maxTextareaHeight}px`;
                 textareaRef.current.style.overflowY = 'auto';
             } else {
                 // Otherwise, fit height to content and hide scrollbar
@@ -147,7 +153,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
                 textareaRef.current.style.overflowY = 'hidden';
             }
         }
-    }, [prompt]);
+    }, [prompt, maxTextareaHeight]);
 
     const canSubmit = !disabled && (!!prompt.trim() || images.length > 0);
 

--- a/services/llmService.ts
+++ b/services/llmService.ts
@@ -36,6 +36,9 @@ export const fetchWithRetry = async (
                 throw new Error(`${serviceName} service is temporarily unavailable. Please try again later.`);
             }
         } catch (error) {
+            if ((error as { name?: string }).name === 'AbortError') {
+                throw error; // don't retry aborted requests
+            }
             if (attempt === retries) {
                 throw error;
             }


### PR DESCRIPTION
## Summary
- make prompt input max height responsive and use valid translucent background
- propagate abort signals through DeepConf strategies and avoid retrying after cancellation
- expose orchestration abort handle before dispatch completes

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'react-virtuoso'; Cannot find module 'wasm-feature-detect'; Parameter '_' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fd9e40cc832280e4651a7319804e