### PR TITLE
refactor: extract deepconf trace provider

### DIFF
--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -115,6 +115,41 @@ const runExpertGeminiSingle = async (
     }
 }
 
+const createDeepConfTraceProvider = <C extends AgentConfig>(
+    runFn: (
+        expert: ExpertDispatch,
+        prompt: string,
+        images: ImageState[],
+        config: C,
+        abortSignal?: AbortSignal
+    ) => Promise<string>,
+    expert: ExpertDispatch,
+    images: ImageState[],
+    config: C,
+    orchestrationAbortSignal?: AbortSignal
+): TraceProvider => {
+    return {
+        generate: async (p, signal) => {
+            if (orchestrationAbortSignal?.aborted) {
+                const abortErr = new Error('Aborted');
+                abortErr.name = 'AbortError';
+                throw abortErr;
+            }
+            const { signal: finalSignal, cleanup } = combineAbortSignals(signal, orchestrationAbortSignal);
+            try {
+                const text = await runFn(expert, p, images, config, finalSignal);
+                const trace: Trace = {
+                    text,
+                    steps: text.split('').map(char => ({ token: char, topK: [] })),
+                };
+                return trace;
+            } finally {
+                cleanup();
+            }
+        }
+    };
+};
+
 const runExpertGeminiDeepConf = async (
     expert: ExpertDispatch,
     prompt: string,
@@ -124,29 +159,7 @@ const runExpertGeminiDeepConf = async (
 ): Promise<string> => {
     const { generationStrategy, traceCount, deepConfEta, tau, groupWindow } = config.settings;
 
-    const createProvider = (): TraceProvider => {
-        return {
-            generate: async (p, signal) => { // p is the prompt string
-                if (abortSignal?.aborted) {
-                    const abortErr = new Error('Aborted');
-                    abortErr.name = 'AbortError';
-                    throw abortErr;
-                }
-                const { signal: finalSignal, cleanup } = combineAbortSignals(signal, abortSignal);
-                try {
-                    const text = await runExpertGeminiSingle(expert, p, images, config, finalSignal);
-                    // Gemini API doesn't give us steps/tokens, so we create a mock Trace
-                    const trace: Trace = {
-                        text,
-                        steps: text.split('').map(char => ({ token: char, topK: [] })), // Mock steps
-                    };
-                    return trace;
-                } finally {
-                    cleanup();
-                }
-            }
-        };
-    };
+    const provider = createDeepConfTraceProvider(runExpertGeminiSingle, expert, images, config, abortSignal);
 
     const extractAnswer = (trace: Trace) => trace.text.trim();
 
@@ -159,10 +172,10 @@ const runExpertGeminiDeepConf = async (
     };
 
     if (generationStrategy === 'deepconf-online') {
-        const { content } = await deepConfOnlineWithJudge(createProvider(), prompt, extractAnswer, config.model, opts);
+        const { content } = await deepConfOnlineWithJudge(provider, prompt, extractAnswer, config.model, opts);
         return content;
     } else { // deepconf-offline
-        const { content } = await deepConfOfflineWithJudge(createProvider(), prompt, extractAnswer, config.model, opts);
+        const { content } = await deepConfOfflineWithJudge(provider, prompt, extractAnswer, config.model, opts);
         return content;
     }
 }
@@ -219,30 +232,7 @@ const runExpertOpenAIDeepConf = async (
 ): Promise<string> => {
     const { generationStrategy, traceCount, deepConfEta, tau, groupWindow } = config.settings;
 
-    const createProvider = (): TraceProvider => {
-        return {
-            generate: async (p, signal) => { // p is the prompt string
-                if (abortSignal?.aborted) {
-                    const abortErr = new Error('Aborted');
-                    abortErr.name = 'AbortError';
-                    throw abortErr;
-                }
-                const { signal: finalSignal, cleanup } = combineAbortSignals(signal, abortSignal);
-                try {
-                    // Since logprobs are not available, we generate the full text and mock the trace.
-                    const text = await runExpertOpenAISingle(expert, p, images, config, finalSignal);
-                    // Mock Trace for judge-based DeepConf
-                    const trace: Trace = {
-                        text,
-                        steps: text.split('').map(char => ({ token: char, topK: [] })), // Mock steps
-                    };
-                    return trace;
-                } finally {
-                    cleanup();
-                }
-            }
-        };
-    };
+    const provider = createDeepConfTraceProvider(runExpertOpenAISingle, expert, images, config, abortSignal);
 
     const extractAnswer = (trace: Trace) => trace.text.trim();
     
@@ -256,10 +246,10 @@ const runExpertOpenAIDeepConf = async (
 
     // Use judge-based DeepConf for OpenAI, similar to Gemini, as logprobs are not available.
     if (generationStrategy === 'deepconf-online') {
-        const { content } = await deepConfOnlineWithJudge(createProvider(), prompt, extractAnswer, config.model, opts);
+        const { content } = await deepConfOnlineWithJudge(provider, prompt, extractAnswer, config.model, opts);
         return content;
     } else { // deepconf-offline
-        const { content } = await deepConfOfflineWithJudge(createProvider(), prompt, extractAnswer, config.model, opts);
+        const { content } = await deepConfOfflineWithJudge(provider, prompt, extractAnswer, config.model, opts);
         return content;
     }
 };


### PR DESCRIPTION
## Summary
- consolidate DeepConf trace provider logic into reusable helper
- reuse helper for Gemini and OpenAI DeepConf strategies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b407ed76c08322929b286a7d91fc73