### PR TITLE
fix: improve DeepConf trace provider abort and token handling

### DIFF
--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -131,16 +131,14 @@ const createDeepConfTraceProvider = <C extends AgentConfig>(
     return {
         generate: async (p, signal) => {
             if (orchestrationAbortSignal?.aborted) {
-                const abortErr = new Error('Aborted');
-                abortErr.name = 'AbortError';
-                throw abortErr;
+                throw new DOMException('Aborted', 'AbortError');
             }
             const { signal: finalSignal, cleanup } = combineAbortSignals(signal, orchestrationAbortSignal);
             try {
                 const text = await runFn(expert, p, images, config, finalSignal);
                 const trace: Trace = {
                     text,
-                    steps: text.split('').map(char => ({ token: char, topK: [] })),
+                    steps: Array.from(text).map(char => ({ token: char, topK: [] })),
                 };
                 return trace;
             } finally {


### PR DESCRIPTION
## Summary
- use `DOMException` for abort errors in DeepConf trace provider
- iterate characters with `Array.from` to handle multi-codepoint tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4096b64d88322a86b5f7b2dc8568e