### PR TITLE
fix: streamline abort handling and drain pending drafts

### DIFF
--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -108,10 +108,11 @@ const runExpertGeminiSingle = async (
         );
         return getGeminiResponseText(response);
     } catch (error) {
-        if (error instanceof Error) {
-            if (error.name === 'AbortError' || error.message === 'Gemini request timed out') {
-                throw error;
-            }
+        if (
+            error instanceof Error &&
+            (error.name === 'AbortError' || error.message === 'Gemini request timed out')
+        ) {
+            throw error;
         }
         return handleGeminiError(error, 'dispatcher', 'dispatch');
     }
@@ -130,9 +131,8 @@ const createDeepConfTraceProvider = <C extends AgentConfig>(
     config: C,
     orchestrationAbortSignal?: AbortSignal
 ): TraceProvider => {
-    const SegmenterCtor = (Intl as any).Segmenter;
-    const segmenter = SegmenterCtor
-        ? new SegmenterCtor(undefined, { granularity: 'grapheme' })
+    const segmenter = globalThis.Intl?.Segmenter
+        ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
         : undefined;
     return {
         generate: async (p, signal) => {

--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -123,8 +123,9 @@ const createDeepConfTraceProvider = <C extends AgentConfig>(
     config: C,
     orchestrationAbortSignal?: AbortSignal
 ): TraceProvider => {
-    const segmenter = globalThis.Intl?.Segmenter
-        ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    const SegmenterCtor = (Intl as any).Segmenter;
+    const segmenter = SegmenterCtor
+        ? new SegmenterCtor(undefined, { granularity: 'grapheme' })
         : undefined;
     return {
         generate: async (p, signal) => {

--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -91,11 +91,6 @@ const runExpertGeminiSingle = async (
     try {
         const response = await callWithGeminiRetry(
             (signal) => {
-                if (abortSignal?.aborted) {
-                    const abortErr = new Error('Aborted');
-                    abortErr.name = 'AbortError';
-                    return Promise.reject(abortErr);
-                }
                 const { signal: finalSignal, cleanup } = combineAbortSignals(signal, abortSignal);
                 if (generateContentParams.config) {
                     generateContentParams.config.abortSignal = finalSignal;
@@ -133,9 +128,6 @@ const createDeepConfTraceProvider = <C extends AgentConfig>(
         : undefined;
     return {
         generate: async (p, signal) => {
-            if (orchestrationAbortSignal?.aborted) {
-                throw new DOMException('Aborted', 'AbortError');
-            }
             const { signal: finalSignal, cleanup } = combineAbortSignals(signal, orchestrationAbortSignal);
             try {
                 const text = await runFn(expert, p, images, config, finalSignal);
@@ -412,20 +404,22 @@ export const dispatch = async (
         draftPromises.push(promise);
     });
 
-    // Run all OpenAI experts sequentially with a delay to avoid rate limits
-    for (const { expert, config } of openAIExperts) {
-        const promise = runExpert(expert, prompt, images, config, abortSignal).then(draft => {
-            onDraftComplete(draft);
-            return draft;
-        });
-        draftPromises.push(promise);
-        await promise;
-        if (abortSignal?.aborted) {
-            throw new DOMException('Aborted', 'AbortError');
+    try {
+        // Run all OpenAI experts sequentially with a delay to avoid rate limits
+        for (const { expert, config } of openAIExperts) {
+            const promise = runExpert(expert, prompt, images, config, abortSignal).then(draft => {
+                onDraftComplete(draft);
+                return draft;
+            });
+            draftPromises.push(promise);
+            await promise;
+            if (config.settings.generationStrategy === 'single') {
+                await delay(OPENAI_REQUEST_DELAY_MS);
+            }
         }
-        if (config.settings.generationStrategy === 'single') {
-            await delay(OPENAI_REQUEST_DELAY_MS);
-        }
+        return await Promise.all(draftPromises);
+    } finally {
+        // Ensure all expert promises settle to avoid unhandled rejections when dispatch is aborted
+        await Promise.allSettled(draftPromises);
     }
-    return Promise.all(draftPromises);
 };

--- a/services/geminiUtils.ts
+++ b/services/geminiUtils.ts
@@ -45,6 +45,9 @@ export const callWithGeminiRetry = async <T>(
                 continue;
             }
             if (error instanceof Error && error.name === 'AbortError') {
+                if (!controller.signal.aborted) {
+                    throw error;
+                }
                 throw new Error('Gemini request timed out');
             }
             if (isRateLimit) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable", "ES2020.Intl"],
     "module": "ESNext",
     "skipLibCheck": true,
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable", "ES2020.Intl"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable", "ES2022.Intl"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
## Summary
- remove redundant abort checks and rely on `combineAbortSignals`
- document that dispatcher waits for all expert promises to settle

## Testing
- `npx vitest run`
- `npm run build` *(fails: Cannot find module 'react-virtuoso'; Cannot find module 'wasm-feature-detect'; Property 'Segmenter' does not exist on type 'typeof Intl')*

------
https://chatgpt.com/codex/tasks/task_e_68b48a66d0a88322bb7f59c168453e00