### PR TITLE
fix: handle AbortError cleanup

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -468,18 +468,13 @@ const App: React.FC = () => {
             } finally {
                 reader.releaseLock();
             }
-            
-            if (animationFrameId.current) {
-                cancelAnimationFrame(animationFrameId.current);
-            }
-            
             if (chunkBuffer) {
                 fullText += chunkBuffer;
                 setFinalAnswer(fullText);
             }
 
         } catch (e) {
-            if (e instanceof DOMException && e.name === 'AbortError') {
+            if (e instanceof Error && e.name === 'AbortError') {
                 return;
             }
             console.error(e);
@@ -488,6 +483,9 @@ const App: React.FC = () => {
             setAgents(prev => prev.map(a => ({...a, status: 'FAILED', error: errorMessage})))
             setAgentConfigs(configs => configs.map(c => ({...c, status: 'FAILED' })));
         } finally {
+            if (animationFrameId.current) {
+                cancelAnimationFrame(animationFrameId.current);
+            }
             orchestratorAbortRef.current = null;
             setIsLoading(false);
             setIsArbiterRunning(false);

--- a/App.tsx
+++ b/App.tsx
@@ -475,6 +475,7 @@ const App: React.FC = () => {
 
         } catch (e) {
             if (e instanceof Error && e.name === 'AbortError') {
+                currentRunDataRef.current = undefined;
                 return;
             }
             console.error(e);

--- a/App.tsx
+++ b/App.tsx
@@ -474,7 +474,7 @@ const App: React.FC = () => {
             }
 
         } catch (e) {
-            if (e instanceof Error && e.name === 'AbortError') {
+            if (typeof e === 'object' && e !== null && 'name' in e && (e as any).name === 'AbortError') {
                 currentRunDataRef.current = undefined;
                 return;
             }


### PR DESCRIPTION
## Summary
- treat any `AbortError` as a user cancellation instead of surfacing a failure
- cancel the streaming animation frame in `finally` to avoid leaks when runs abort

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'react-virtuoso'; Cannot find module 'wasm-feature-detect')*

------
https://chatgpt.com/codex/tasks/task_e_68b4aff733b083228e1ec56df36690bf