### PR TITLE
feat: add selectable dark themes and refine typography

### DIFF
--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -126,7 +126,7 @@ const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>((props
                 {currentRunStatus !== 'IDLE' && (
                     <div className="mb-1">
                         <button
-                            onClick={onViewCurrentRun} // View current run without resetting
+                            onClick={onViewCurrentRun}
                             className={`w-full text-left flex items-center gap-3 p-2 rounded-md transition-colors ${
                                 !selectedRunId ? 'bg-[var(--surface-1)]' : 'hover:bg-[var(--surface-active)]'
                             }`}

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -155,29 +155,28 @@ const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>((props
                         data={history}
                         style={{ height: '100%' }}
                         components={{
-                            List: forwardRef<HTMLDivElement>((props, ref) => (
-                                <div {...props} ref={ref} className="space-y-1" />
+                            List: forwardRef<HTMLUListElement>((props, ref) => (
+                                <ul {...props} ref={ref} className="space-y-1" />
                             )),
+                            Item: (props) => <li {...props} />,
                         }}
                         itemContent={(_index: number, run: RunRecord) => (
-                            <div>
-                                <button
-                                    onClick={() => onSelectRun(run.id)}
-                                    className={`w-full text-left flex items-center gap-3 p-2 rounded-md transition-colors ${
-                                        selectedRunId === run.id ? 'bg-[var(--surface-1)]' : 'hover:bg-[var(--surface-active)]'
-                                    }`}
-                                >
-                                    <div className="flex-shrink-0 w-4 h-4 flex items-center justify-center mt-0.5">
-                                        <StatusIndicator status={run.status} />
+                            <button
+                                onClick={() => onSelectRun(run.id)}
+                                className={`w-full text-left flex items-center gap-3 p-2 rounded-md transition-colors ${
+                                    selectedRunId === run.id ? 'bg-[var(--surface-1)]' : 'hover:bg-[var(--surface-active)]'
+                                }`}
+                            >
+                                <div className="flex-shrink-0 w-4 h-4 flex items-center justify-center mt-0.5">
+                                    <StatusIndicator status={run.status} />
+                                </div>
+                                {isOpen && (
+                                    <div className="overflow-hidden">
+                                        <p className="text-sm font-medium text-[var(--text)] truncate">{run.prompt || 'Image-based prompt'}</p>
+                                        <p className="text-xs text-[var(--text-muted)]">{formatTimestamp(run.timestamp)}</p>
                                     </div>
-                                    {isOpen && (
-                                        <div className="overflow-hidden">
-                                            <p className="text-sm font-medium text-[var(--text)] truncate">{run.prompt || 'Image-based prompt'}</p>
-                                            <p className="text-xs text-[var(--text-muted)]">{formatTimestamp(run.timestamp)}</p>
-                                        </div>
-                                    )}
-                                </button>
-                            </div>
+                                )}
+                            </button>
                         )}
                     />
                 )}

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, forwardRef } from 'react';
-import { Virtuoso } from 'react-virtuoso';
+import { Virtuoso, ListProps } from 'react-virtuoso';
 import { RunRecord, RunStatus } from '@/types';
 import { ChevronLeftIcon, ChevronRightIcon, PlusIcon, CheckCircleIcon, XCircleIcon } from '@/components/icons';
 
@@ -155,10 +155,10 @@ const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>((props
                         data={history}
                         style={{ height: '100%' }}
                         components={{
-                            List: forwardRef<HTMLUListElement>((props, ref) => (
-                                <ul {...props} ref={ref} className="space-y-1" />
+                            List: forwardRef<HTMLDivElement, ListProps>((props, ref) => (
+                                <ul {...props} ref={ref as unknown as React.Ref<HTMLUListElement>} className="space-y-1" />
                             )),
-                            Item: (props) => <li {...props} />,
+                            Item: (props: React.LiHTMLAttributes<HTMLLIElement>) => <li {...props} />,
                         }}
                         itemContent={(_index: number, run: RunRecord) => (
                             <button

--- a/lib/ThemeContext.tsx
+++ b/lib/ThemeContext.tsx
@@ -2,6 +2,12 @@ import React, { createContext, useContext, useState, useEffect } from 'react';
 
 export type ThemeName = 'forest' | 'desert' | 'ocean' | 'midnight';
 
+const THEME_STORAGE_KEY = 'heavyorc-theme';
+const THEMES: readonly ThemeName[] = ['forest', 'desert', 'ocean', 'midnight'];
+
+const isValidTheme = (t: string | null): t is ThemeName =>
+  THEMES.includes((t ?? '') as ThemeName);
+
 interface ThemeContextValue {
   theme: ThemeName;
   setTheme: (t: ThemeName) => void;
@@ -12,15 +18,14 @@ const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [theme, setTheme] = useState<ThemeName>(() => {
     if (typeof window === 'undefined') return 'forest';
-    const storedTheme = localStorage.getItem('heavyorc-theme');
-    const isValidTheme = (t: string | null): t is ThemeName => ['forest', 'desert', 'ocean', 'midnight'].includes(t ?? '');
+    const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
     return isValidTheme(storedTheme) ? storedTheme : 'forest';
   });
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
     try {
-      localStorage.setItem('heavyorc-theme', theme);
+      localStorage.setItem(THEME_STORAGE_KEY, theme);
     } catch (e) {
       console.warn('Failed to save theme to localStorage', e);
     }

--- a/lib/ThemeContext.tsx
+++ b/lib/ThemeContext.tsx
@@ -10,10 +10,20 @@ interface ThemeContextValue {
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [theme, setTheme] = useState<ThemeName>('forest');
+  const [theme, setTheme] = useState<ThemeName>(() => {
+    if (typeof window === 'undefined') return 'forest';
+    const storedTheme = localStorage.getItem('heavyorc-theme');
+    const isValidTheme = (t: string | null): t is ThemeName => ['forest', 'desert', 'ocean', 'midnight'].includes(t ?? '');
+    return isValidTheme(storedTheme) ? storedTheme : 'forest';
+  });
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
+    try {
+      localStorage.setItem('heavyorc-theme', theme);
+    } catch (e) {
+      console.warn('Failed to save theme to localStorage', e);
+    }
   }, [theme]);
 
   return (


### PR DESCRIPTION
## Summary
- persist selected theme between sessions via localStorage
- render history list as semantic `<ul>/<li>` elements for better accessibility

## Testing
- `npx vitest run`
- `npm run build` *(fails: Cannot find module 'react-virtuoso'; Parameter 'props' implicitly has an 'any' type; Cannot find module 'wasm-feature-detect')*

------
https://chatgpt.com/codex/tasks/task_e_68b4c467d4fc8322846117c0f64d965b