### PR TITLE
fix: init theme attribute and document casts

### DIFF
--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -155,8 +155,13 @@ const HistorySidebar = forwardRef<HTMLButtonElement, HistorySidebarProps>((props
                         data={history}
                         style={{ height: '100%' }}
                         components={{
+                            // react-virtuoso's List component is typed for a div; cast to render a semantic <ul>
                             List: forwardRef<HTMLDivElement, ListProps>((props, ref) => (
-                                <ul {...(props as any)} ref={ref as unknown as React.Ref<HTMLUListElement>} className="space-y-1" />
+                                <ul
+                                    {...(props as any)}
+                                    ref={ref as unknown as React.Ref<HTMLUListElement>}
+                                    className="space-y-1"
+                                />
                             )),
                             Item: forwardRef<HTMLLIElement, React.ComponentProps<'li'>>((props, ref) => (
                                 <li {...props} ref={ref} />

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="forest">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%assets/favicon.svg" />

--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -141,6 +141,7 @@ const createDeepConfTraceProvider = <C extends AgentConfig>(
                 const text = await runFn(expert, p, images, config, finalSignal);
                 const tokens = segmenter
                     ? Array.from(segmenter.segment(text), ({ segment }) => segment)
+                    // Array.from on a string iterates by code point; complex grapheme clusters may split
                     : Array.from(text);
                 const trace: Trace = {
                     text,


### PR DESCRIPTION
## Summary
- set default `data-theme="forest"` to avoid flash of unstyled content
- comment react-virtuoso list cast and fallback tokenization limitation

## Testing
- `npx vitest run`
- `npm run build` *(fails: Cannot find module 'react-virtuoso'; Cannot find module 'wasm-feature-detect')*

------
https://chatgpt.com/codex/tasks/task_e_68b4da09e40c8322bfb08653a579a14d