### PR TITLE
Handle AbortError without DOMException

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -474,15 +474,15 @@ const App: React.FC = () => {
             }
 
         } catch (e) {
-            if (e instanceof DOMException && e.name === 'AbortError') {
+            if ((e as { name?: string })?.name === 'AbortError') {
                 currentRunDataRef.current = undefined;
                 return;
             }
             console.error(e);
             const errorMessage = e instanceof Error ? e.message : 'An unexpected error occurred.';
             setError(errorMessage);
-            setAgents(prev => prev.map(a => ({...a, status: 'FAILED', error: errorMessage})))
-            setAgentConfigs(configs => configs.map(c => ({...c, status: 'FAILED' })));
+            setAgents(prev => prev.map(a => ({ ...a, status: 'FAILED', error: errorMessage })))
+            setAgentConfigs(configs => configs.map(c => ({ ...c, status: 'FAILED' })));
         } finally {
             if (animationFrameId.current) {
                 cancelAnimationFrame(animationFrameId.current);


### PR DESCRIPTION
## Summary
- Treat any error named `AbortError` during orchestrations as a user cancellation and avoid marking agents as failed.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4dff6d9f88322ae38d2d1be07e223