### PR TITLE
Move background effect styles to theme stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,11 +103,11 @@
         z-index: -1;
         border-radius: inherit; /* Inherit border-radius from parent */
       }
-        /* New class for adaptive grid columns */
-        .grid-adaptive-cols {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-        }
+      /* New class for adaptive grid columns */
+      .grid-adaptive-cols {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+      }
     </style>
   <script type="importmap">
 {

--- a/index.html
+++ b/index.html
@@ -103,28 +103,11 @@
         z-index: -1;
         border-radius: inherit; /* Inherit border-radius from parent */
       }
-      /* Parallax background styles */
-      #background-effects {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        z-index: -1;
-        background-color: #030712; /* A deeper gray-950 for a 'space' feel */
-        background-image:
-            var(--panel-pattern),
-            radial-gradient(circle at 20% 30%, hsla(217, 50%, 80%, 0.04) 0px, transparent 40%),
-            radial-gradient(circle at 80% 70%, hsla(280, 45%, 75%, 0.04) 0px, transparent 40%),
-            radial-gradient(circle at 50% 50%, hsla(0, 0%, 100%, 0.02) 0px, transparent 20%);
-        background-size: 120px 120px, auto, auto, auto;
-        will-change: transform; /* Performance optimization for animation */
-      }
-      /* New class for adaptive grid columns */
-      .grid-adaptive-cols {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-      }
+        /* New class for adaptive grid columns */
+        .grid-adaptive-cols {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+        }
     </style>
   <script type="importmap">
 {

--- a/public/theme.css
+++ b/public/theme.css
@@ -137,3 +137,21 @@ textarea {
 .shadow-md { box-shadow: var(--shadow-md); }
 .shadow-lg { box-shadow: var(--shadow-lg); }
 
+/* Parallax background styles */
+#background-effects {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  background-color: #030712; /* A deeper gray-950 for a 'space' feel */
+  background-image:
+      var(--panel-pattern),
+      radial-gradient(circle at 20% 30%, hsla(217, 50%, 80%, 0.04) 0px, transparent 40%),
+      radial-gradient(circle at 80% 70%, hsla(280, 45%, 75%, 0.04) 0px, transparent 40%),
+      radial-gradient(circle at 50% 50%, hsla(0, 0%, 100%, 0.02) 0px, transparent 20%);
+  background-size: 120px 120px, auto, auto, auto;
+  will-change: transform; /* Performance optimization for animation */
+}
+

--- a/public/theme.css
+++ b/public/theme.css
@@ -145,7 +145,7 @@ textarea {
   width: 100%;
   height: 100%;
   z-index: -1;
-  background-color: #030712; /* A deeper gray-950 for a 'space' feel */
+  background-color: var(--bg);
   background-image:
       var(--panel-pattern),
       radial-gradient(circle at 20% 30%, hsla(217, 50%, 80%, 0.04) 0px, transparent 40%),


### PR DESCRIPTION
## Summary
- relocate `#background-effects` CSS from inline `index.html` style block to `public/theme.css`
- keep `index.html` clean by relying on shared theme stylesheet

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b4fea655ac83228fa269e9d633eb72