### PR TITLE
fix: correct alert background color syntax

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -118,8 +118,8 @@ const Toast: React.FC<{ message: string; type: 'success' | 'error'; onClose: () 
 
     const colorClasses =
         type === 'success'
-            ? 'bg-[var(--success)] border-[var(--success)] text-[var(--text)]'
-            : 'bg-[var(--danger)] border-[var(--danger)] text-[var(--text)]';
+            ? 'bg-success border-success text-[var(--text)]'
+            : 'bg-danger border-danger text-[var(--text)]';
 
     return (
         <div
@@ -928,12 +928,12 @@ const App: React.FC = () => {
                         </header>
 
                         <main className="max-w-4xl mx-auto space-y-8 pb-40">
-                            {error && !displayData.isHistoryView && <div className="p-3 bg-[var(--danger)] bg-opacity-20 text-[var(--danger)] border border-[var(--danger)] rounded-lg text-sm text-center">{error}</div>}
+                            {error && !displayData.isHistoryView && <div className="p-3 bg-danger/20 text-danger border border-danger rounded-lg text-sm text-center">{error}</div>}
 
                             {(openAIAgentCount > 0 && !openAIApiKey) || (openRouterAgentCount > 0 && !openRouterApiKey) && (
-                                <p className="text-xs text-[var(--warn)] text-center p-2 bg-[var(--warn)] bg-opacity-20 rounded-md border border-[var(--warn)]">
+                                <p className="text-xs text-warn text-center p-2 bg-warn/20 rounded-md border border-warn">
                                     An API key is required for one or more of your agents.
-                                    <button onClick={() => setIsSettingsViewOpen(true)} className="ml-1 underline font-semibold hover:text-[var(--warn)] focus:outline-none focus:ring-2 focus:ring-[var(--warn)] rounded">
+                                    <button onClick={() => setIsSettingsViewOpen(true)} className="ml-1 underline font-semibold hover:text-warn focus:outline-none focus:ring-2 focus:ring-warn rounded">
                                         Set API Key
                                     </button>
                                 </p>
@@ -947,13 +947,13 @@ const App: React.FC = () => {
                                     variants={containerVariants}
                                 >
                                     {displayData.arbiterSwitchWarning && (
-                                        <motion.div 
-                                            className="bg-[var(--warn)] bg-opacity-20 border border-[var(--warn)] text-[var(--warn)] px-4 py-3 rounded-lg relative"
+                                        <motion.div
+                                            className="bg-warn/20 border border-warn text-warn px-4 py-3 rounded-lg relative"
                                             role="alert"
                                             variants={itemVariants}
                                         >
                                             <div className="flex items-start">
-                                                <ExclamationTriangleIcon className="w-5 h-5 mr-3 mt-0.5 text-[var(--warn)] flex-shrink-0" aria-hidden="true" />
+                                                <ExclamationTriangleIcon className="w-5 h-5 mr-3 mt-0.5 text-warn flex-shrink-0" aria-hidden="true" />
                                                 <div>
                                                     <strong className="font-bold">Automatic Model Switch:</strong>
                                                     <span className="block sm:inline sm:ml-2">{displayData.arbiterSwitchWarning}</span>

--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -23,9 +23,9 @@ const getStatusIndicator = (status: AgentStatus): React.ReactNode => {
         case 'RUNNING':
             return <><LoadingSpinner className="h-5 w-5 text-[var(--accent-2)] animate-spin" /><span className="sr-only">Running</span></>;
         case 'COMPLETED':
-            return <><CheckCircleIcon className="h-5 w-5 text-[var(--success)]" /><span className="sr-only">Completed</span></>;
+            return <><CheckCircleIcon className="h-5 w-5 text-success" /><span className="sr-only">Completed</span></>;
         case 'FAILED':
-            return <><XCircleIcon className="h-5 w-5 text-[var(--danger)]" /><span className="sr-only">Failed</span></>;
+            return <><XCircleIcon className="h-5 w-5 text-danger" /><span className="sr-only">Failed</span></>;
         case 'PENDING':
         default:
             return <><EllipsisHorizontalIcon className="h-5 w-5 text-[var(--text-muted)]" /><span className="sr-only">Pending</span></>;
@@ -37,9 +37,9 @@ const getBorderColor = (status: AgentStatus): string => {
         case 'RUNNING':
             return 'border-[var(--accent-2)] animate-pulse';
         case 'COMPLETED':
-            return 'border-[var(--success)]';
+            return 'border-success';
         case 'FAILED':
-            return 'border-[var(--danger)]';
+            return 'border-danger';
         case 'PENDING':
         default:
             return 'border-[var(--line)]';
@@ -53,7 +53,7 @@ const getProviderChipStyle = (provider: AgentState['provider']): string => {
         case 'openai':
             return 'bg-[var(--accent-2)] text-[#0D1411]';
         case 'openrouter':
-            return 'bg-[var(--success)] text-[#0D1411]';
+            return 'bg-success text-[#0D1411]';
         default:
             return 'bg-[var(--surface-1)] text-[var(--text)]';
     }

--- a/components/AgentConfigCard.tsx
+++ b/components/AgentConfigCard.tsx
@@ -19,9 +19,9 @@ const getStatusIndicator = (status: AgentStatus): React.ReactNode => {
         case 'RUNNING':
             return <LoadingSpinner className="h-5 w-5 text-[var(--accent-2)] animate-spin" aria-hidden="true" />;
         case 'COMPLETED':
-            return <CheckCircleIcon className="h-5 w-5 text-[var(--success)]" aria-hidden="true" />;
+            return <CheckCircleIcon className="h-5 w-5 text-success" aria-hidden="true" />;
         case 'FAILED':
-            return <XCircleIcon className="h-5 w-5 text-[var(--danger)]" aria-hidden="true" />;
+            return <XCircleIcon className="h-5 w-5 text-danger" aria-hidden="true" />;
         case 'PENDING':
         case 'QUEUED':
         default:
@@ -34,9 +34,9 @@ const getBorderColor = (status: AgentStatus): string => {
         case 'RUNNING':
             return 'border-[var(--accent-2)] ring-2 ring-[var(--accent-2)] ring-opacity-50';
         case 'COMPLETED':
-            return 'border-[var(--success)]';
+            return 'border-success';
         case 'FAILED':
-            return 'border-[var(--danger)]';
+            return 'border-danger';
         case 'PENDING':
         case 'QUEUED':
         default:
@@ -140,7 +140,7 @@ const AgentConfigCard: React.FC<AgentConfigCardProps> = ({ config, onUpdate, onR
                 <button 
                     onClick={() => onRemove(config.id)} 
                     disabled={disabled} 
-                    className="p-1 text-[var(--text-muted)] hover:text-[var(--danger)] disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="p-1 text-[var(--text-muted)] hover:text-danger disabled:opacity-50 disabled:cursor-not-allowed"
                     title="Remove Agent"
                 >
                     <XCircleIcon className="w-5 h-5" aria-hidden="true" />

--- a/components/HistorySidebar.tsx
+++ b/components/HistorySidebar.tsx
@@ -53,13 +53,13 @@ const StatusIndicator: React.FC<{ status: RunStatus }> = ({ status }) => {
         case 'COMPLETED':
             return (
                 <div title="Completed">
-                    <CheckCircleIcon className="w-4 h-4 text-[var(--success)]" aria-hidden="true" />
+                    <CheckCircleIcon className="w-4 h-4 text-success" aria-hidden="true" />
                 </div>
             );
         case 'FAILED':
             return (
                 <div title="Failed">
-                    <XCircleIcon className="w-4 h-4 text-[var(--danger)]" aria-hidden="true" />
+                    <XCircleIcon className="w-4 h-4 text-danger" aria-hidden="true" />
                 </div>
             );
         default:

--- a/components/ImageInput.tsx
+++ b/components/ImageInput.tsx
@@ -78,7 +78,7 @@ const ImageInput: React.FC<ImageInputProps> = ({ image, onImageChange, disabled 
                         <button
                             onClick={handleRemoveImage}
                             disabled={disabled}
-                            className="p-2 bg-[var(--danger)] bg-opacity-80 text-[var(--text)] rounded-full hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-[var(--danger)] focus:ring-offset-2 focus:ring-offset-[var(--surface-1)] disabled:opacity-50"
+                            className="p-2 bg-danger/80 text-[var(--text)] rounded-full hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-danger focus:ring-offset-2 focus:ring-offset-[var(--surface-1)] disabled:opacity-50"
                             aria-label="Remove image"
                         >
                             <XCircleIcon className="w-6 h-6" aria-hidden="true" />

--- a/components/PromptInput.tsx
+++ b/components/PromptInput.tsx
@@ -179,7 +179,7 @@ const PromptInput: React.FC<PromptInputProps> = ({
                             <button
                                 onClick={() => handleRemoveImage(img.id)}
                                 disabled={disabled || isLoading}
-                                className="absolute top-1 right-1 p-0.5 bg-black/60 text-[var(--text)] rounded-full hover:bg-[var(--danger)] focus:outline-none focus:ring-2 focus:ring-[var(--danger)] disabled:opacity-50"
+                                className="absolute top-1 right-1 p-0.5 bg-black/60 text-[var(--text)] rounded-full hover:bg-danger focus:outline-none focus:ring-2 focus:ring-danger disabled:opacity-50"
                                 aria-label="Remove image"
                             >
                                 <XCircleIcon className="w-5 h-5" aria-hidden="true" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -45,6 +45,11 @@ export default {
         md: 'var(--shadow-md)',
         lg: 'var(--shadow-lg)',
       },
+      colors: {
+        danger: 'rgb(var(--danger) / <alpha-value>)',
+        warn: 'rgb(var(--warn) / <alpha-value>)',
+        success: 'rgb(var(--success) / <alpha-value>)',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- define danger, warn, and success colors in Tailwind theme
- replace arbitrary CSS variables with semantic alert classes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50a9df4ec832286f6d63d80631d9b