### PR TITLE
fix: improve Gemini error handling and env fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ VITE_APP_URL=https://your-domain.example
 
 Keys are optional; the UI hides providers without keys. `VITE_APP_URL` supplies a referer for server-side deployments.
 
+The application reads the Gemini key from `GEMINI_API_KEY` (falling back to a legacy `API_KEY` if present).
+
 ## Reasoning models and context management
 
 Reasoning models such as GPT‑5 and GPT‑5‑mini generate internal reasoning tokens before returning a final answer. These tokens count against the model's context window and are billed as output tokens. To avoid incomplete responses:

--- a/moe/dispatcher.ts
+++ b/moe/dispatcher.ts
@@ -2,7 +2,7 @@ import { GenerateContentParameters, Part } from "@google/genai";
 import { Draft, ExpertDispatch } from './types';
 import { getGeminiClient, getOpenAIClient, getOpenRouterApiKey, callWithRetry, fetchWithRetry } from '@/services/llmService';
 import { getAppUrl, getGeminiResponseText, combineAbortSignals } from '@/lib/utils';
-import { callWithGeminiRetry, handleGeminiError } from '@/services/geminiUtils';
+import { callWithGeminiRetry, handleGeminiError, isAbortError } from '@/services/geminiUtils';
 import { GEMINI_PRO_MODEL, GEMINI_FLASH_MODEL, OPENAI_REASONING_PROMPT_PREFIX } from '@/constants';
 import { AgentConfig, GeminiAgentConfig, ImageState, OpenAIAgentConfig, GeminiThinkingEffort, OpenRouterAgentConfig } from '@/types';
 import {
@@ -109,10 +109,9 @@ const runExpertGeminiSingle = async (
         return getGeminiResponseText(response);
     } catch (error) {
         if (
-            error instanceof Error &&
-            (error.name === 'AbortError' || error.message === 'Gemini request timed out')
+            (isAbortError(error) || (error instanceof Error && error.message === 'Gemini request timed out'))
         ) {
-            throw error;
+            throw error as Error;
         }
         return handleGeminiError(error, 'dispatcher', 'dispatch');
     }

--- a/services/llmService.ts
+++ b/services/llmService.ts
@@ -98,10 +98,10 @@ export const getGeminiClient = (): GoogleGenAI => {
         return geminiClient;
     }
 
-    const apiKey = currentGeminiApiKey || process.env.API_KEY;
+    const apiKey = currentGeminiApiKey || process.env.GEMINI_API_KEY || process.env.API_KEY;
 
     if (!apiKey) {
-        throw new Error("Gemini API key is missing. Please add it via the settings menu or ensure the API_KEY environment variable is set.");
+        throw new Error("Gemini API key is missing. Please add it via the settings menu or ensure the GEMINI_API_KEY environment variable (or legacy API_KEY) is set.");
     }
 
     geminiClient = new GoogleGenAI({ apiKey });

--- a/tests/llmService.test.ts
+++ b/tests/llmService.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@google/genai', () => {
+  return { GoogleGenAI: vi.fn() };
+});
+
+describe('getGeminiClient environment variables', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.API_KEY;
+  });
+
+  it('uses GEMINI_API_KEY when set', async () => {
+    process.env.GEMINI_API_KEY = 'env-key';
+    const { getGeminiClient } = await import('@/services/llmService');
+    const { GoogleGenAI } = await import('@google/genai');
+    getGeminiClient();
+    expect(GoogleGenAI).toHaveBeenCalledWith({ apiKey: 'env-key' });
+  });
+
+  it('falls back to API_KEY when GEMINI_API_KEY is absent', async () => {
+    process.env.API_KEY = 'legacy-key';
+    const { getGeminiClient } = await import('@/services/llmService');
+    const { GoogleGenAI } = await import('@google/genai');
+    getGeminiClient();
+    expect(GoogleGenAI).toHaveBeenCalledWith({ apiKey: 'legacy-key' });
+  });
+});


### PR DESCRIPTION
## Summary
- handle abort conditions from Gemini API by detecting aborted errors and timing out
- load Gemini API key from `GEMINI_API_KEY` env var with legacy `API_KEY` fallback
- document and test new Gemini API key behaviour

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b51a2b6b388322b66ae5274272abe4