### PR TITLE
ci: verify package-lock integrity

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: sha256sum -c package-lock.json.sha256
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,10 @@ permissions:
   contents: write
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
+      - name: Verify package-lock.json integrity
+        run: |
+          echo "Verifying package-lock.json integrity..."
+          sha256sum -c package-lock.json.sha256 || (echo "ERROR: package-lock.json integrity check failed!" && exit 1)
       - uses: actions/checkout@v4
       - run: sha256sum -c package-lock.json.sha256
       - uses: actions/setup-node@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: sha256sum -c package-lock.json.sha256
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/package-lock.json.sha256
+++ b/package-lock.json.sha256
@@ -1,0 +1,1 @@
+9f533436059aa174dacf05a7d565e0f6aedbdf5824cdda93fb8d929818b18c46  package-lock.json


### PR DESCRIPTION
## Summary
- verify package-lock.json with sha256sum in workflows
- commit hash file for package-lock.json

## Testing
- `sha256sum -c package-lock.json.sha256`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b5258325d48322867f9fd2df1b93f1