### PR TITLE
Improve Gemini dispatch timing and streaming

### DIFF
--- a/moe/types.ts
+++ b/moe/types.ts
@@ -13,4 +13,14 @@ export interface Draft {
   content: string;
   status: AgentStatus;
   error?: string | null;
+  /**
+   * True when the draft content represents a partial response produced before an error occurred.
+   * When set, `error` should contain details about the failure that interrupted generation.
+   */
+  isPartial?: boolean;
+  /**
+   * For partial responses, indicates the estimated percentage of completion (0-100).
+   * Helps clients understand how much of the expected response was received.
+   */
+  completionPercentage?: number;
 }

--- a/moe/types.ts
+++ b/moe/types.ts
@@ -18,9 +18,4 @@ export interface Draft {
    * When set, `error` should contain details about the failure that interrupted generation.
    */
   isPartial?: boolean;
-  /**
-   * For partial responses, indicates the estimated percentage of completion (0-100).
-   * Helps clients understand how much of the expected response was received.
-   */
-  completionPercentage?: number;
 }

--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -27,13 +27,17 @@ describe('dispatcher Gemini failure handling', () => {
   });
 
   it('records a failed draft when Gemini returns 503 and continues with others', async () => {
-    const generateContent = vi
+    const generateContentStream = vi
       .fn()
       .mockRejectedValueOnce({ status: 503 })
-      .mockResolvedValueOnce({ text: () => 'ok' });
+      .mockResolvedValueOnce({
+        [Symbol.asyncIterator]: async function* () {
+          yield { text: () => 'ok' };
+        },
+      });
 
     (getGeminiClient as unknown as Mock).mockReturnValue({
-      models: { generateContent },
+      models: { generateContentStream },
     });
     const { dispatch } = await import('@/moe/dispatcher');
 

--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Mock } from 'vitest';
 import { ExpertDispatch } from '@/moe/types';
 import { GEMINI_FLASH_MODEL } from '@/constants';
-import type { GeminiAgentConfig } from '@/types';
+import { MAX_GEMINI_TIMEOUT_MS, type GeminiAgentConfig } from '@/types';
 import { getGeminiClient } from '@/services/llmService';
 
 vi.mock('@/services/llmService', () => ({
@@ -74,5 +74,258 @@ describe('dispatcher Gemini failure handling', () => {
     expect(failDraft?.status).toBe('FAILED');
     expect(okDraft?.status).toBe('COMPLETED');
     expect(okDraft?.content).toBe('ok');
+  });
+});
+
+describe('dispatcher Gemini streaming', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    process.env.GEMINI_RETRY_COUNT = '0';
+    process.env.GEMINI_BACKOFF_MS = '1';
+  });
+
+  afterEach(() => {
+    delete process.env.GEMINI_RETRY_COUNT;
+    delete process.env.GEMINI_BACKOFF_MS;
+  });
+
+  const baseConfig = {
+    provider: 'gemini',
+    model: GEMINI_FLASH_MODEL,
+    status: 'PENDING',
+    settings: {
+      effort: 'low',
+      generationStrategy: 'single',
+      confidenceSource: 'judge',
+      traceCount: 1,
+      deepConfEta: 90,
+      tau: 0.95,
+      groupWindow: 2048,
+    },
+  } as const;
+
+  it('concatenates multiple stream chunks', async () => {
+    const generateContentStream = vi.fn().mockResolvedValue({
+      [Symbol.asyncIterator]: async function* () {
+        yield { text: () => 'hello ' };
+        yield { text: () => 'world' };
+      },
+    });
+
+    (getGeminiClient as unknown as Mock).mockReturnValue({
+      models: { generateContentStream },
+    });
+    const { dispatch } = await import('@/moe/dispatcher');
+
+    const expert: ExpertDispatch = {
+      agentId: 'multi',
+      provider: 'gemini',
+      model: GEMINI_FLASH_MODEL,
+      id: '1',
+      name: 'multi',
+      persona: '',
+    };
+    const config: GeminiAgentConfig = { ...baseConfig, id: 'multi', expert };
+
+    const drafts = await dispatch([expert], 'prompt', [], [config], () => {}, undefined);
+
+    expect(drafts[0].content).toBe('hello world');
+  });
+
+  it('returns partial result when stream errors', async () => {
+    const generateContentStream = vi.fn().mockResolvedValue({
+      [Symbol.asyncIterator]: async function* () {
+        yield { text: () => 'partial' };
+        throw new Error('stream error');
+      },
+    });
+
+    (getGeminiClient as unknown as Mock).mockReturnValue({
+      models: { generateContentStream },
+    });
+    const { dispatch } = await import('@/moe/dispatcher');
+
+    const expert: ExpertDispatch = {
+      agentId: 'partial',
+      provider: 'gemini',
+      model: GEMINI_FLASH_MODEL,
+      id: '1',
+      name: 'partial',
+      persona: '',
+    };
+    const config: GeminiAgentConfig = { ...baseConfig, id: 'partial', expert };
+
+    const drafts = await dispatch([expert], 'prompt', [], [config], () => {}, undefined);
+
+    expect(drafts[0].content).toBe('partial');
+    expect(drafts[0].status).toBe('COMPLETED');
+    expect(drafts[0].isPartial).toBe(true);
+  });
+});
+
+describe('dispatcher Gemini timeout', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    process.env.GEMINI_RETRY_COUNT = '0';
+    process.env.GEMINI_BACKOFF_MS = '1';
+  });
+
+  afterEach(() => {
+    delete process.env.GEMINI_RETRY_COUNT;
+    delete process.env.GEMINI_BACKOFF_MS;
+  });
+
+  const baseConfig = {
+    provider: 'gemini',
+    model: GEMINI_FLASH_MODEL,
+    status: 'PENDING',
+    settings: {
+      effort: 'low',
+      generationStrategy: 'single',
+      confidenceSource: 'judge',
+      traceCount: 1,
+      deepConfEta: 90,
+      tau: 0.95,
+      groupWindow: 2048,
+    },
+  } as const;
+
+  it('fails when stream exceeds timeout before first chunk', async () => {
+    const generateContentStream = vi.fn((params) => {
+      const signal = params.config?.abortSignal;
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          await new Promise<void>((resolve) => {
+            const t = setTimeout(resolve, 1500);
+            signal?.addEventListener('abort', () => {
+              clearTimeout(t);
+              resolve();
+            });
+          });
+          if (signal?.aborted) {
+            throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+          }
+          yield { text: () => 'late' };
+        },
+      };
+    });
+
+    (getGeminiClient as unknown as Mock).mockReturnValue({ models: { generateContentStream } });
+    const { dispatch } = await import('@/moe/dispatcher');
+
+    const expert: ExpertDispatch = {
+      agentId: 'timeout1',
+      provider: 'gemini',
+      model: GEMINI_FLASH_MODEL,
+      id: '1',
+      name: 'timeout1',
+      persona: '',
+    };
+    const config: GeminiAgentConfig = { ...baseConfig, id: 'timeout1', expert, settings: { ...baseConfig.settings, timeoutMs: 1000 } };
+
+    const drafts = await dispatch([expert], 'prompt', [], [config], () => {}, undefined);
+
+    expect(drafts[0].status).toBe('FAILED');
+    expect(drafts[0].error).toMatch(/^Expert "timeout1" exceeded the configured timeout/);
+  });
+
+  it('fails when timeout occurs during streaming', async () => {
+    const generateContentStream = vi.fn((params) => {
+      const signal = params.config?.abortSignal;
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          yield { text: () => 'early' };
+          await new Promise<void>((resolve) => {
+            const t = setTimeout(resolve, 1500);
+            signal?.addEventListener('abort', () => {
+              clearTimeout(t);
+              resolve();
+            });
+          });
+          if (signal?.aborted) {
+            throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+          }
+          yield { text: () => 'late' };
+        },
+      };
+    });
+
+    (getGeminiClient as unknown as Mock).mockReturnValue({ models: { generateContentStream } });
+    const { dispatch } = await import('@/moe/dispatcher');
+
+    const expert: ExpertDispatch = {
+      agentId: 'timeout2',
+      provider: 'gemini',
+      model: GEMINI_FLASH_MODEL,
+      id: '1',
+      name: 'timeout2',
+      persona: '',
+    };
+    const config: GeminiAgentConfig = { ...baseConfig, id: 'timeout2', expert, settings: { ...baseConfig.settings, timeoutMs: 1000 } };
+
+    const drafts = await dispatch([expert], 'prompt', [], [config], () => {}, undefined);
+
+    expect(drafts[0].status).toBe('FAILED');
+    expect(drafts[0].error).toMatch(/^Expert "timeout2" exceeded the configured timeout/);
+  });
+
+  it('handles minimum valid timeout correctly', async () => {
+    const generateContentStream = vi.fn().mockResolvedValue({
+      [Symbol.asyncIterator]: async function* () {
+        yield { text: () => 'ok' };
+      },
+    });
+
+    (getGeminiClient as unknown as Mock).mockReturnValue({ models: { generateContentStream } });
+    const { dispatch } = await import('@/moe/dispatcher');
+
+    const expert: ExpertDispatch = {
+      agentId: 'minTimeout',
+      provider: 'gemini',
+      model: GEMINI_FLASH_MODEL,
+      id: '1',
+      name: 'minTimeout',
+      persona: '',
+    };
+    const config: GeminiAgentConfig = {
+      ...baseConfig,
+      id: 'minTimeout',
+      expert,
+      settings: { ...baseConfig.settings, timeoutMs: 1001 }
+    };
+
+    const drafts = await dispatch([expert], 'prompt', [], [config], () => {}, undefined);
+    expect(drafts[0].status).toBe('COMPLETED');
+  });
+
+  it('handles maximum valid timeout correctly', async () => {
+    const generateContentStream = vi.fn().mockResolvedValue({
+      [Symbol.asyncIterator]: async function* () {
+        yield { text: () => 'ok' };
+      },
+    });
+
+    (getGeminiClient as unknown as Mock).mockReturnValue({ models: { generateContentStream } });
+    const { dispatch } = await import('@/moe/dispatcher');
+
+    const expert: ExpertDispatch = {
+      agentId: 'maxTimeout',
+      provider: 'gemini',
+      model: GEMINI_FLASH_MODEL,
+      id: '1',
+      name: 'maxTimeout',
+      persona: '',
+    };
+    const config: GeminiAgentConfig = {
+      ...baseConfig,
+      id: 'maxTimeout',
+      expert,
+      settings: { ...baseConfig.settings, timeoutMs: MAX_GEMINI_TIMEOUT_MS - 1 }
+    };
+
+    const drafts = await dispatch([expert], 'prompt', [], [config], () => {}, undefined);
+    expect(drafts[0].status).toBe('COMPLETED');
   });
 });

--- a/types.ts
+++ b/types.ts
@@ -85,18 +85,17 @@ const CommonAgentSettingsSchema = z.object({
     groupWindow: z.number().optional(),
 }).strict();
 
+export const MAX_GEMINI_TIMEOUT_MS = 300000;
+
 const GeminiAgentSettingsSchema: z.ZodType<Partial<GeminiAgentSettings>> =
     CommonAgentSettingsSchema.extend({
         effort: z.enum(['dynamic', 'high', 'medium', 'low', 'none']).optional(),
         // Restrict timeout to reasonable bounds to avoid misconfiguration
-const MAX_GEMINI_TIMEOUT_MS = 300000;
-
-timeoutMs: z
-    .number()
-    .int()
-    .min(1000)
-    .max(MAX_GEMINI_TIMEOUT_MS)
-    .optional(),
+        timeoutMs: z
+            .number()
+            .int()
+            .min(1000)
+            .max(MAX_GEMINI_TIMEOUT_MS)
             .optional(),
     }).strict();
 


### PR DESCRIPTION
## Summary
- add `MAX_GEMINI_TIMEOUT_MS` and export it for reuse
- switch Gemini dispatcher to streamed responses with progress logging
- validate custom timeouts and use `performance.now()` for precise elapsed timing

## Testing
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52e5422588322ae9a2f1b75b7d52a