### PR TITLE
Integrate Cipher memory layer

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -60,6 +60,7 @@ import { storeRunRecord, fetchRelevantMemories } from '@/services/cipherService'
 // Hooks
 import useViewportHeight from '@/lib/useViewportHeight';
 import useKeydown from '@/lib/useKeydown';
+import { escapeHtml } from '@/lib/utils';
 
 // Session migration
 import { migrateAgentConfig } from '@/lib/sessionMigration';
@@ -377,11 +378,19 @@ const App: React.FC = () => {
             return;
         }
 
-        const memories = await fetchRelevantMemories(finalPrompt);
-        if (memories.length > 0) {
-            const memoryText = memories.map(m => m.content).join('\n');
-            finalPrompt = `${memoryText}\n\n${finalPrompt}`;
-            setToast({ message: `Including ${memories.length} relevant memories from history...`, type: 'success' });
+        try {
+            const memories = await fetchRelevantMemories(finalPrompt);
+            if (memories.length > 0) {
+                const memoryText = memories.map(m => m.content).join('\n');
+                finalPrompt = `${memoryText}\n\n${finalPrompt}`;
+                setToast({ message: `Including ${memories.length} relevant memories from history...`, type: 'success' });
+            }
+        } catch (error) {
+            console.error('Error fetching memories:', error);
+            setToast({ 
+              message: `Failed to fetch memories: ${error instanceof Error ? (error.name === 'NetworkError' ? 'Network connection issue' : escapeHtml(error.message)) : 'Unknown error'}`, 
+              type: 'error' 
+            });
         }
 
         orchestratorAbortRef.current?.();

--- a/App.tsx
+++ b/App.tsx
@@ -377,14 +377,11 @@ const App: React.FC = () => {
             return;
         }
 
-        try {
-            const memories = await fetchRelevantMemories(finalPrompt);
-            if (memories.length > 0) {
-                const memoryText = memories.map(m => m.content).join('\n');
-                finalPrompt = `${memoryText}\n\n${finalPrompt}`;
-            }
-        } catch {
-            /* ignore memory errors */
+        const memories = await fetchRelevantMemories(finalPrompt);
+        if (memories.length > 0) {
+            const memoryText = memories.map(m => m.content).join('\n');
+            finalPrompt = `${memoryText}\n\n${finalPrompt}`;
+            setToast({ message: `Including ${memories.length} relevant memories from history...`, type: 'success' });
         }
 
         orchestratorAbortRef.current?.();

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,6 +14,12 @@ export const getGeminiResponseText = (response: unknown): string => {
     : (textProp as string | undefined) ?? '';
 };
 
+export const escapeHtml = (str: string): string => {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+};
+
 export const combineAbortSignals = (
   ...signals: (AbortSignal | undefined)[]
 ): { signal: AbortSignal; cleanup: () => void } => {

--- a/services/cipherService.ts
+++ b/services/cipherService.ts
@@ -7,10 +7,20 @@ export interface MemoryEntry {
 }
 
 const useCipher = import.meta.env.VITE_USE_CIPHER_MEMORY === 'true';
-const baseUrl = import.meta.env.VITE_CIPHER_SERVER_URL ?? 'http://localhost:3000';
+const baseUrl = validateUrl(import.meta.env.VITE_CIPHER_SERVER_URL);
+
+function validateUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    return ['http:', 'https:'].includes(parsed.protocol) ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 export const storeRunRecord = async (run: RunRecord): Promise<void> => {
-  if (!useCipher) return;
+  if (!useCipher || !baseUrl) return;
   try {
     const response = await fetchWithRetry(`${baseUrl}/memories`, {
       method: 'POST',
@@ -18,15 +28,18 @@ export const storeRunRecord = async (run: RunRecord): Promise<void> => {
       body: JSON.stringify({ run }),
     });
     if (!response.ok) {
-      console.warn('Failed to store run record');
+      console.warn(`Failed to store run record: ${response.status} ${response.statusText}`);
+      const errorData = await response.text().catch(() => 'Unable to read error response');
+      console.debug('Error details:', errorData);
     }
-  } catch {
+  } catch (e) {
+    console.warn('Failed to store run record:', e);
     // Swallow errors to avoid breaking the app when memory is unreachable
   }
 };
 
 export const fetchRelevantMemories = async (query: string): Promise<MemoryEntry[]> => {
-  if (!useCipher) return [];
+  if (!useCipher || !baseUrl) return [];
   try {
     const response = await fetchWithRetry(`${baseUrl}/memories/search`, {
       method: 'POST',
@@ -34,11 +47,13 @@ export const fetchRelevantMemories = async (query: string): Promise<MemoryEntry[
       body: JSON.stringify({ query }),
     });
     if (!response.ok) {
+      console.warn(`Failed to fetch memories, server responded with ${response.status}`);
       return [];
     }
     const data = await response.json() as { memories?: MemoryEntry[] };
     return Array.isArray(data.memories) ? data.memories : [];
-  } catch {
+  } catch (e) {
+    console.warn('Failed to fetch relevant memories:', e);
     return [];
   }
 };

--- a/services/cipherService.ts
+++ b/services/cipherService.ts
@@ -9,14 +9,60 @@ export interface MemoryEntry {
 const useCipher = import.meta.env.VITE_USE_CIPHER_MEMORY === 'true';
 const baseUrl = validateUrl(import.meta.env.VITE_CIPHER_SERVER_URL);
 
-function validateUrl(url: string | undefined): string | undefined {
+function sanitizeErrorResponse(body: string): string {
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const SENSITIVE_PATTERNS = [
+        /auth(orization)?/i,
+        /token/i,
+        /password/i,
+        /secret/i,
+        /key/i,
+      ];
+      for (const key of Object.keys(parsed)) {
+        if (SENSITIVE_PATTERNS.some(p => p.test(key))) {
+          (parsed as Record<string, unknown>)[key] = '[REDACTED]';
+        }
+      }
+      return JSON.stringify(parsed);
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return '[REDACTED]';
+}
+
+export function validateUrl(url: string | undefined): string | undefined {
   if (!url) return undefined;
   try {
     const parsed = new URL(url);
-    return ['http:', 'https:'].includes(parsed.protocol) ? url : undefined;
+    return ['http:', 'https:'].includes(parsed.protocol) && !isPrivateOrLocalhost(parsed.hostname) ? url : undefined;
   } catch {
     return undefined;
   }
+}
+
+function isPrivateOrLocalhost(hostname: string): boolean {
+  const host = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+  const lower = host.toLowerCase();
+  if (lower === 'localhost' || lower === '::1' || lower === '::') return true;
+  if (lower.startsWith('127.') || lower.startsWith('192.168.') || lower.startsWith('10.') || /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(lower)) return true;
+  if (lower.startsWith('::ffff:')) {
+    const mapped = lower.slice(7);
+    if (/^(\d{1,3}\.){3}\d{1,3}$/.test(mapped)) {
+      if (isPrivateOrLocalhost(mapped)) return true;
+    } else {
+      const parts = mapped.split(':');
+      if (parts.length === 2 && parts.every(p => /^[0-9a-f]{1,4}$/.test(p))) {
+        const [a, b] = parts.map(p => parseInt(p, 16));
+        const ipv4 = `${a >> 8}.${a & 255}.${b >> 8}.${b & 255}`;
+        if (isPrivateOrLocalhost(ipv4)) return true;
+      }
+    }
+  }
+  return /^fe[89ab][0-9a-f]*:/.test(lower) ||
+    /^f[cd][0-9a-f]*:/.test(lower);
 }
 
 export const storeRunRecord = async (run: RunRecord): Promise<void> => {
@@ -28,12 +74,19 @@ export const storeRunRecord = async (run: RunRecord): Promise<void> => {
       body: JSON.stringify({ run }),
     });
     if (!response.ok) {
-      console.warn(`Failed to store run record: ${response.status} ${response.statusText}`);
       const errorData = await response.text().catch(() => 'Unable to read error response');
-      console.debug('Error details:', errorData);
+      console.error('Failed to store run record', {
+        url: `${baseUrl}/memories`,
+        status: response.status,
+        statusText: response.statusText,
+        body: sanitizeErrorResponse(errorData),
+      });
     }
   } catch (e) {
-    console.warn('Failed to store run record:', e);
+    console.error('Failed to store run record', {
+      url: `${baseUrl}/memories`,
+      error: e,
+    });
     // Swallow errors to avoid breaking the app when memory is unreachable
   }
 };
@@ -47,13 +100,22 @@ export const fetchRelevantMemories = async (query: string): Promise<MemoryEntry[
       body: JSON.stringify({ query }),
     });
     if (!response.ok) {
-      console.warn(`Failed to fetch memories, server responded with ${response.status}`);
+      const errorData = await response.text().catch(() => 'Unable to read error response');
+      console.error('Failed to fetch memories', {
+        url: `${baseUrl}/memories/search`,
+        status: response.status,
+        statusText: response.statusText,
+        body: sanitizeErrorResponse(errorData),
+      });
       return [];
     }
     const data = await response.json() as { memories?: MemoryEntry[] };
     return Array.isArray(data.memories) ? data.memories : [];
   } catch (e) {
-    console.warn('Failed to fetch relevant memories:', e);
+    console.error('Failed to fetch relevant memories', {
+      url: `${baseUrl}/memories/search`,
+      error: e,
+    });
     return [];
   }
 };

--- a/tests/cipherService.test.ts
+++ b/tests/cipherService.test.ts
@@ -37,21 +37,22 @@ describe('cipherService', () => {
     expect(fetchMock).toHaveBeenCalledWith('http://cipher/memories', expect.any(Object));
   });
 
-  it('fetches memories and handles network errors', async () => {
+  it('fetches memories when enabled', async () => {
     vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
     vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
     const data = { memories: [{ id: '1', content: 'note' }] };
     const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(data), { status: 200 }));
     global.fetch = fetchMock as any;
-    let { fetchRelevantMemories } = await import('@/services/cipherService');
+    const { fetchRelevantMemories } = await import('@/services/cipherService');
     const memories = await fetchRelevantMemories('q');
     expect(memories).toEqual(data.memories);
+  });
 
-    vi.resetModules();
+  it('returns an empty array on network errors when fetching memories', async () => {
     vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
     vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
     global.fetch = vi.fn().mockRejectedValue(new Error('network')) as any;
-    ({ fetchRelevantMemories } = await import('@/services/cipherService'));
+    const { fetchRelevantMemories } = await import('@/services/cipherService');
     const empty = await fetchRelevantMemories('q');
     expect(empty).toEqual([]);
   });

--- a/tests/cipherService.test.ts
+++ b/tests/cipherService.test.ts
@@ -67,4 +67,52 @@ describe('cipherService', () => {
     expect(fetchMock).not.toHaveBeenCalled();
     expect(res).toEqual([]);
   });
+
+  it('redacts sensitive info in error responses', async () => {
+    vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
+    vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
+    const body = JSON.stringify({ token: 'abc', Password: 'secret' });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(body, { status: 400, statusText: 'fail' }));
+    global.fetch = fetchMock as any;
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { storeRunRecord } = await import('@/services/cipherService');
+    await storeRunRecord(sampleRun);
+    const logged = consoleSpy.mock.calls[0][1] as any;
+    expect(logged.body).toBe('{"token":"[REDACTED]","Password":"[REDACTED]"}');
+    consoleSpy.mockRestore();
+  });
+
+  it('redacts arrays in error responses', async () => {
+    vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
+    vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
+    const fetchMock = vi.fn().mockResolvedValue(new Response('[{"token":"abc"}]', { status: 400, statusText: 'fail' }));
+    global.fetch = fetchMock as any;
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { storeRunRecord } = await import('@/services/cipherService');
+    await storeRunRecord(sampleRun);
+    const logged = consoleSpy.mock.calls[0][1] as any;
+    expect(logged.body).toBe('[REDACTED]');
+    consoleSpy.mockRestore();
+  });
+
+  it('validates URLs and blocks private addresses', async () => {
+    const { validateUrl } = await import('@/services/cipherService');
+    expect(validateUrl('http://example.com')).toBe('http://example.com');
+    expect(validateUrl('https://example.com')).toBe('https://example.com');
+    expect(validateUrl('http://example.com:8080')).toBe('http://example.com:8080');
+    expect(validateUrl('http://localhost')).toBeUndefined();
+    expect(validateUrl('http://127.0.0.1')).toBeUndefined();
+    expect(validateUrl('http://192.168.0.1')).toBeUndefined();
+    expect(validateUrl('http://10.0.0.1')).toBeUndefined();
+    expect(validateUrl('http://172.16.0.1')).toBeUndefined();
+    expect(validateUrl('http://[::1]')).toBeUndefined();
+    expect(validateUrl('http://[::]')).toBeUndefined();
+    expect(validateUrl('http://[fd00::1]')).toBeUndefined();
+    expect(validateUrl('http://[fe80::1]')).toBeUndefined();
+    expect(validateUrl('http://[2001:db8::1]')).toBe('http://[2001:db8::1]');
+    expect(validateUrl('http://[2001:db8:0:1::]')).toBe('http://[2001:db8:0:1::]');
+    expect(validateUrl('http://[::ffff:192.168.0.1]')).toBeUndefined();
+    expect(validateUrl('http://[fe80:::1]')).toBeUndefined();
+    expect(validateUrl('ftp://example.com')).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- validate Cipher URL and add warning logs for memory service failures
- surface memory injection with a toast
- split cipher memory tests

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b57cf0c74c83228f636ba54fcf3397