### PR TITLE
fix: harden Cipher memory URL and error handling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -377,11 +377,16 @@ const App: React.FC = () => {
             return;
         }
 
-        const memories = await fetchRelevantMemories(finalPrompt);
-        if (memories.length > 0) {
-            const memoryText = memories.map(m => m.content).join('\n');
-            finalPrompt = `${memoryText}\n\n${finalPrompt}`;
-            setToast({ message: `Including ${memories.length} relevant memories from history...`, type: 'success' });
+        try {
+            const memories = await fetchRelevantMemories(finalPrompt);
+            if (memories.length > 0) {
+                const memoryText = memories.map(m => m.content).join('\n');
+                finalPrompt = `${memoryText}\n\n${finalPrompt}`;
+                setToast({ message: `Including ${memories.length} relevant memories from history...`, type: 'success' });
+            }
+        } catch (error) {
+            console.error('Error fetching memories:', error);
+            setToast({ message: 'Failed to fetch relevant memories', type: 'error' });
         }
 
         orchestratorAbortRef.current?.();

--- a/tests/cipherService.test.ts
+++ b/tests/cipherService.test.ts
@@ -67,4 +67,16 @@ describe('cipherService', () => {
     expect(fetchMock).not.toHaveBeenCalled();
     expect(res).toEqual([]);
   });
+
+  it('validates URLs and blocks private addresses', async () => {
+    const { validateUrl } = await import('@/services/cipherService');
+    expect(validateUrl('http://example.com')).toBe('http://example.com');
+    expect(validateUrl('https://example.com')).toBe('https://example.com');
+    expect(validateUrl('http://localhost')).toBeUndefined();
+    expect(validateUrl('http://127.0.0.1')).toBeUndefined();
+    expect(validateUrl('http://192.168.0.1')).toBeUndefined();
+    expect(validateUrl('http://10.0.0.1')).toBeUndefined();
+    expect(validateUrl('http://172.16.0.1')).toBeUndefined();
+    expect(validateUrl('ftp://example.com')).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- block private IPs/localhost in Cipher URL validation
- log status text and body when Cipher memory requests fail
- restore try-catch around memory fetch and add validation tests

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b57f20c1908322bc50251f9656e6dc