### PR TITLE
fix: expand cipher URL and logging safeguards

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -387,7 +387,10 @@ const App: React.FC = () => {
             }
         } catch (error) {
             console.error('Error fetching memories:', error);
-            setToast({ message: `Failed to fetch memories: ${error instanceof Error ? escapeHtml(error.message) : 'Unknown error'}`, type: 'error' });
+            setToast({ 
+              message: `Failed to fetch memories: ${error instanceof Error ? (error.name === 'NetworkError' ? 'Network connection issue' : escapeHtml(error.message)) : 'Unknown error'}`, 
+              type: 'error' 
+            });
         }
 
         orchestratorAbortRef.current?.();

--- a/App.tsx
+++ b/App.tsx
@@ -60,6 +60,7 @@ import { storeRunRecord, fetchRelevantMemories } from '@/services/cipherService'
 // Hooks
 import useViewportHeight from '@/lib/useViewportHeight';
 import useKeydown from '@/lib/useKeydown';
+import { escapeHtml } from '@/lib/utils';
 
 // Session migration
 import { migrateAgentConfig } from '@/lib/sessionMigration';
@@ -386,7 +387,7 @@ const App: React.FC = () => {
             }
         } catch (error) {
             console.error('Error fetching memories:', error);
-            setToast({ message: `Failed to fetch memories: ${error instanceof Error ? error.message : 'Unknown error'}`, type: 'error' });
+            setToast({ message: `Failed to fetch memories: ${error instanceof Error ? escapeHtml(error.message) : 'Unknown error'}`, type: 'error' });
         }
 
         orchestratorAbortRef.current?.();

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,6 +14,15 @@ export const getGeminiResponseText = (response: unknown): string => {
     : (textProp as string | undefined) ?? '';
 };
 
+export const escapeHtml = (str: string): string =>
+  str.replace(/[&<>"']/g, c => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[c]!));
+
 export const combineAbortSignals = (
   ...signals: (AbortSignal | undefined)[]
 ): { signal: AbortSignal; cleanup: () => void } => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,14 +14,11 @@ export const getGeminiResponseText = (response: unknown): string => {
     : (textProp as string | undefined) ?? '';
 };
 
-export const escapeHtml = (str: string): string =>
-  str.replace(/[&<>"']/g, c => ({
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#39;',
-  }[c]!));
+export const escapeHtml = (str: string): string => {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+};
 
 export const combineAbortSignals = (
   ...signals: (AbortSignal | undefined)[]

--- a/services/cipherService.ts
+++ b/services/cipherService.ts
@@ -50,22 +50,13 @@ function isPrivateOrLocalhost(hostname: string): boolean {
   if (lower.startsWith('127.') || lower.startsWith('192.168.') || lower.startsWith('10.') || /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(lower)) return true;
   if (lower.startsWith('::ffff:')) {
     const mapped = lower.slice(7);
-    if (mapped.includes('.')) {
-      const parts = mapped.split('.');
-      if (parts.length === 4 && parts.every(p => {
-        const n = Number(p);
-        return p !== '' && Number.isInteger(n) && n >= 0 && n <= 255;
-      }) && isPrivateOrLocalhost(mapped)) return true;
+    if (/^(\d{1,3}\.){3}\d{1,3}$/.test(mapped)) {
+      if (isPrivateOrLocalhost(mapped)) return true;
     } else {
       const parts = mapped.split(':');
-      if (parts.length === 2) {
-        const num = (parseInt(parts[0], 16) << 16) + parseInt(parts[1], 16);
-        const ipv4 = [
-          (num >>> 24) & 255,
-          (num >>> 16) & 255,
-          (num >>> 8) & 255,
-          num & 255,
-        ].join('.');
+      if (parts.length === 2 && parts.every(p => /^[0-9a-f]{1,4}$/.test(p))) {
+        const [a, b] = parts.map(p => parseInt(p, 16));
+        const ipv4 = `${a >> 8}.${a & 255}.${b >> 8}.${b & 255}`;
         if (isPrivateOrLocalhost(ipv4)) return true;
       }
     }

--- a/tests/cipherService.test.ts
+++ b/tests/cipherService.test.ts
@@ -68,6 +68,33 @@ describe('cipherService', () => {
     expect(res).toEqual([]);
   });
 
+  it('redacts sensitive info in error responses', async () => {
+    vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
+    vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
+    const body = JSON.stringify({ token: 'abc', Password: 'secret' });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(body, { status: 400, statusText: 'fail' }));
+    global.fetch = fetchMock as any;
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { storeRunRecord } = await import('@/services/cipherService');
+    await storeRunRecord(sampleRun);
+    const logged = consoleSpy.mock.calls[0][1] as any;
+    expect(logged.body).toBe('{"token":"[REDACTED]","Password":"[REDACTED]"}');
+    consoleSpy.mockRestore();
+  });
+
+  it('redacts arrays in error responses', async () => {
+    vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
+    vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
+    const fetchMock = vi.fn().mockResolvedValue(new Response('[{"token":"abc"}]', { status: 400, statusText: 'fail' }));
+    global.fetch = fetchMock as any;
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { storeRunRecord } = await import('@/services/cipherService');
+    await storeRunRecord(sampleRun);
+    const logged = consoleSpy.mock.calls[0][1] as any;
+    expect(logged.body).toBe('[REDACTED]');
+    consoleSpy.mockRestore();
+  });
+
   it('validates URLs and blocks private addresses', async () => {
     const { validateUrl } = await import('@/services/cipherService');
     expect(validateUrl('http://example.com')).toBe('http://example.com');

--- a/tests/cipherService.test.ts
+++ b/tests/cipherService.test.ts
@@ -79,9 +79,13 @@ describe('cipherService', () => {
     expect(validateUrl('http://10.0.0.1')).toBeUndefined();
     expect(validateUrl('http://172.16.0.1')).toBeUndefined();
     expect(validateUrl('http://[::1]')).toBeUndefined();
+    expect(validateUrl('http://[::]')).toBeUndefined();
     expect(validateUrl('http://[fd00::1]')).toBeUndefined();
     expect(validateUrl('http://[fe80::1]')).toBeUndefined();
     expect(validateUrl('http://[2001:db8::1]')).toBe('http://[2001:db8::1]');
+    expect(validateUrl('http://[2001:db8:0:1::]')).toBe('http://[2001:db8:0:1::]');
+    expect(validateUrl('http://[::ffff:192.168.0.1]')).toBeUndefined();
+    expect(validateUrl('http://[fe80:::1]')).toBeUndefined();
     expect(validateUrl('ftp://example.com')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- sanitize Cipher service error logs and IPv6 private range detection including IPv4-mapped addresses
- escape memory fetch errors before showing toast to users
- add IPv6 edge case tests for URL validation

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b598ea32e8832295565ab5ae52f855