### PR TITLE
Integrate Cipher memory layer

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import JSZip from 'jszip';
 import { motion, Variants } from 'framer-motion';
 import FocusTrap from 'focus-trap-react';
+import escapeHtml from 'escape-html';
 
 // Types and constants
 import {
@@ -383,16 +384,17 @@ const App: React.FC = () => {
             return;
         }
 
+        setIsLoading(true);
+
         const memories = await fetchRelevantMemories(finalPrompt);
         if (memories.length > 0) {
-            const memoryText = memories.map(m => m.content).join('\n');
+            const memoryText = memories.map(m => escapeHtml(m.content)).join('\n');
             finalPrompt = `Context from previous interactions:\n${memoryText}\n\nCurrent request:\n${finalPrompt}`;
             setToast({ message: `Including ${memories.length} relevant memories from history...`, type: 'success' });
         }
 
         orchestratorAbortRef.current?.();
         orchestratorAbortRef.current = null;
-        setIsLoading(true);
         setError(null);
         setFinalAnswer('');
         setIsArbiterRunning(false);

--- a/App.tsx
+++ b/App.tsx
@@ -384,15 +384,6 @@ const App: React.FC = () => {
             return;
         }
 
-        setIsLoading(true);
-
-        const memories = await fetchRelevantMemories(finalPrompt);
-        if (memories.length > 0) {
-            const memoryText = memories.map(m => escapeHtml(m.content)).join('\n');
-            finalPrompt = `Context from previous interactions:\n${memoryText}\n\nCurrent request:\n${finalPrompt}`;
-            setToast({ message: `Including ${memories.length} relevant memories from history...`, type: 'success' });
-        }
-
         orchestratorAbortRef.current?.();
         orchestratorAbortRef.current = null;
         setError(null);
@@ -400,19 +391,27 @@ const App: React.FC = () => {
         setIsArbiterRunning(false);
         setAgents([]);
         setArbiterSwitchWarning(null);
-        
-        isRunCompletedRef.current = false;
-        currentRunDataRef.current = {
-            prompt: finalPrompt,
-            images,
-            agentConfigs,
-            arbiterModel,
-            openAIArbiterVerbosity,
-            openAIArbiterEffort,
-            geminiArbiterEffort
-        };
-        
+
         try {
+            setIsLoading(true);
+
+            const memories = await fetchRelevantMemories(finalPrompt);
+            if (memories.length > 0) {
+                const memoryText = memories.map(m => escapeHtml(m.content)).join('\n');
+                finalPrompt = `Context from previous interactions:\n${memoryText}\n\nCurrent request:\n${finalPrompt}`;
+                setToast({ message: `Including ${memories.length} relevant memories from history...`, type: 'success' });
+            }
+
+            isRunCompletedRef.current = false;
+            currentRunDataRef.current = {
+                prompt: finalPrompt,
+                images,
+                agentConfigs,
+                arbiterModel,
+                openAIArbiterVerbosity,
+                openAIArbiterEffort,
+                geminiArbiterEffort
+            };
             const onInitialAgents = (dispatchedExperts: ExpertDispatch[]) => {
                 const initialAgents = dispatchedExperts.map((expert): AgentState => ({
                     id: expert.agentId,

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -1,34 +1,50 @@
+const SENSITIVE_PATTERNS = [
+  /auth(orization)?/i,
+  /token/i,
+  /password/i,
+  /secret/i,
+  /key/i,
+  /credential/i,
+  /api[-_]?key/i,
+  /cert(ificate)?/i,
+  /connection[-_]?string/i,
+  /private[-_]?key/i,
+  /session[-_]?id/i,
+];
+
+const BASE64_VALUE = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+function sanitizeObject(obj: Record<string, unknown>): Record<string, unknown> {
+  const sanitized = { ...obj };
+  for (const [key, value] of Object.entries(sanitized)) {
+    if (
+      SENSITIVE_PATTERNS.some(p => p.test(key)) ||
+      (typeof value === 'string' && value.length >= 40 && BASE64_VALUE.test(value))
+    ) {
+      sanitized[key] = '[REDACTED]';
+    }
+  }
+  return sanitized;
+}
+
 export function sanitizeErrorResponse(body: string): string {
   try {
     const parsed = JSON.parse(body);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      const SENSITIVE_PATTERNS = [
-        /auth(orization)?/i,
-        /token/i,
-        /password/i,
-        /secret/i,
-        /key/i,
-        /credential/i,
-        /api[-_]?key/i,
-        /cert(ificate)?/i,
-        /connection[-_]?string/i,
-        /private[-_]?key/i,
-        /session[-_]?id/i,
-      ];
-      const BASE64_VALUE = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
-      for (const [key, value] of Object.entries(parsed)) {
-        if (
-          SENSITIVE_PATTERNS.some(p => p.test(key)) ||
-          (typeof value === 'string' && value.length >= 40 && BASE64_VALUE.test(value))
-        ) {
-          (parsed as Record<string, unknown>)[key] = '[REDACTED]';
-        }
-      }
-      return JSON.stringify(parsed);
+    if (Array.isArray(parsed)) {
+      return JSON.stringify(
+        parsed.map(item =>
+          item && typeof item === 'object' && !Array.isArray(item)
+            ? sanitizeObject(item)
+            : item
+        )
+      );
+    }
+    if (parsed && typeof parsed === 'object') {
+      return JSON.stringify(sanitizeObject(parsed as Record<string, unknown>));
     }
   } catch {
     // ignore parse errors
   }
-  // Arrays and non-JSON responses are redacted to avoid leaking sensitive data
+  // For safety, non-JSON-object/array responses are fully redacted.
   return '[REDACTED]';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@byterover/cipher": "^0.3.0",
         "@dqbd/tiktoken": "^1.0.22",
         "@google/genai": "^1.15.0",
+        "escape-html": "^1.0.3",
         "focus-trap-react": "^11.0.4",
         "framer-motion": "^11.3.12",
         "ipaddr.js": "^1.9.1",
@@ -23,6 +24,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@types/escape-html": "^1.0.2",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.2.0",
@@ -3106,6 +3108,13 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/escape-html": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
+      "integrity": "sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@byterover/cipher": "^0.3.0",
     "@dqbd/tiktoken": "^1.0.22",
     "@google/genai": "^1.15.0",
+    "escape-html": "^1.0.3",
     "focus-trap-react": "^11.0.4",
     "framer-motion": "^11.3.12",
     "ipaddr.js": "^1.9.1",
@@ -30,6 +31,7 @@
   "devDependencies": {
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/escape-html": "^1.0.2",
     "@vitejs/plugin-react": "^4.2.0",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",

--- a/tests/cipherService.test.ts
+++ b/tests/cipherService.test.ts
@@ -149,7 +149,7 @@ describe('cipherService', () => {
     const { storeRunRecord } = await import('@/services/cipherService');
     await storeRunRecord(sampleRun);
     const logged = consoleSpy.mock.calls[0][1] as any;
-    expect(logged.body).toBe('[REDACTED]');
+    expect(logged.body).toBe('[{"token":"[REDACTED]"}]');
     consoleSpy.mockRestore();
   });
 

--- a/tests/cipherService.test.ts
+++ b/tests/cipherService.test.ts
@@ -107,6 +107,7 @@ describe('cipherService', () => {
       'private_key': 'pk',
       session_id: 'sess',
       encoded: 'YWJjMTIzYWJjMTIzYWJjMTIzYWJjMTIzYWJjMTIz',
+      shortEncoded: 'YWJjZGVmZ2hpamtsbW4=',
     });
     const headers = {
       'Content-Security-Policy':
@@ -125,7 +126,7 @@ describe('cipherService', () => {
     await storeRunRecord(sampleRun);
     const logged = consoleSpy.mock.calls[0][1] as any;
     expect(logged.body).toBe(
-      '{"token":"[REDACTED]","Password":"[REDACTED]","certificate":"[REDACTED]","connection-string":"[REDACTED]","private_key":"[REDACTED]","session_id":"[REDACTED]","encoded":"[REDACTED]"}'
+      '{"token":"[REDACTED]","Password":"[REDACTED]","certificate":"[REDACTED]","connection-string":"[REDACTED]","private_key":"[REDACTED]","session_id":"[REDACTED]","encoded":"[REDACTED]","shortEncoded":"[REDACTED]"}'
     );
     consoleSpy.mockRestore();
   });
@@ -138,7 +139,7 @@ describe('cipherService', () => {
         "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src 'self'",
     };
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response('[{"token":"abc"}]', {
+      new Response('[{"token":"abc"},"my-secret-token"]', {
         status: 400,
         statusText: 'fail',
         headers,
@@ -149,7 +150,36 @@ describe('cipherService', () => {
     const { storeRunRecord } = await import('@/services/cipherService');
     await storeRunRecord(sampleRun);
     const logged = consoleSpy.mock.calls[0][1] as any;
-    expect(logged.body).toBe('[{"token":"[REDACTED]"}]');
+    expect(logged.body).toBe('[{"token":"[REDACTED]"},"[REDACTED]"]');
+    consoleSpy.mockRestore();
+  });
+
+  it('recursively redacts nested data in error responses', async () => {
+    vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
+    vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
+    const headers = {
+      'Content-Security-Policy':
+        "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src 'self'",
+    };
+    const responseBody = JSON.stringify({
+      details: {
+        token: 'abc',
+        items: ['secret', { password: 'p' }],
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(responseBody, {
+        status: 400,
+        statusText: 'fail',
+        headers,
+      })
+    );
+    global.fetch = fetchMock as any;
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { storeRunRecord } = await import('@/services/cipherService');
+    await storeRunRecord(sampleRun);
+    const logged = consoleSpy.mock.calls[0][1] as any;
+    expect(logged.body).toBe('{"details":{"token":"[REDACTED]","items":["[REDACTED]",{"password":"[REDACTED]"}]}}');
     consoleSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- guard against duplicate runs before memory fetch and sanitize injected memory text
- refine error-response sanitization to handle arrays
- include escape-html dependency and typings

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5e3cbd7b483228f4d7b939e003f7a