### PR TITLE
Integrate Cipher memory layer

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import JSZip from 'jszip';
 import { motion, Variants } from 'framer-motion';
 import FocusTrap from 'focus-trap-react';
-import escapeHtml from 'escape-html';
+import { escapeHtml } from '@/lib/utils';
 
 // Types and constants
 import {

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -17,6 +17,7 @@ const BASE64_SHORT = /^[A-Za-z0-9+/]{16,}={0,2}$/;
 
 function isSensitiveString(value: string): boolean {
   return (
+    SENSITIVE_PATTERNS.some(p => p.test(value)) ||
     (value.length >= 20 && BASE64_VALUE.test(value)) ||
     BASE64_SHORT.test(value)
   );
@@ -29,9 +30,7 @@ function isSensitiveString(value: string): boolean {
  */
 function sanitize(data: unknown): unknown {
   if (Array.isArray(data)) {
-    return data.map(item =>
-      item && typeof item === 'object' ? sanitize(item) : '[REDACTED]'
-    );
+    return data.map(item => sanitize(item));
   }
 
   if (data && typeof data === 'object' && data !== null) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,5 @@
+import escapeHtmlImpl from 'escape-html';
+
 export const getAppUrl = (): string =>
   typeof window !== 'undefined' && window.location
     ? window.location.origin
@@ -14,11 +16,7 @@ export const getGeminiResponseText = (response: unknown): string => {
     : (textProp as string | undefined) ?? '';
 };
 
-export const escapeHtml = (str: string): string => {
-  const div = document.createElement('div');
-  div.textContent = str;
-  return div.innerHTML;
-};
+export const escapeHtml = (str: string): string => escapeHtmlImpl(str);
 
 export const combineAbortSignals = (
   ...signals: (AbortSignal | undefined)[]


### PR DESCRIPTION
## Summary
- centralize HTML escaping via shared utility
- refine error-response sanitization and array handling
- relax memory server CSP validation to parse directives

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ee81fa34832286d7001cffd9c7ad