### PR TITLE
feat: sanitize memory context and error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ VITE_CIPHER_SERVER_URL=http://localhost:3000
 
 If the server is not running, HeavyOrc continues to operate with ephemeral in-memory history. Cipher speaks the Model Context Protocol, so the same memory store can be shared with other tools in the future.
 
+Fetched memory snippets are HTML-escaped before being included in prompts, and error responses are recursively redacted so logs don't leak tokens, passwords, or other secrets.
+
 ## Reasoning models and context management
 
 Reasoning models such as GPT‑5 and GPT‑5‑mini generate internal reasoning tokens before returning a final answer. These tokens count against the model's context window and are billed as output tokens. To avoid incomplete responses:


### PR DESCRIPTION
## Summary
- centralize HTML escaping utility and sanitize fetched memory context before augmenting prompts
- redact sensitive fields recursively in error responses and log arrays safely
- relax CSP validation to require `'self'` in `connect-src` or `default-src`
- document sanitized memories and redacted error logs

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5f4052a9c8322954345bc72cf9d22