### PR TITLE
fix: preserve non-sensitive array items

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ VITE_CIPHER_SERVER_URL=http://localhost:3000
 If the server is not running, HeavyOrc continues to operate with ephemeral in-memory history. Cipher speaks the Model Context Protocol, so the same memory store can be shared with other tools in the future.
 
 Fetched memory snippets are HTML-escaped with [`escape-html`](https://www.npmjs.com/package/escape-html), replacing characters like `&`, `<`, `>`, `"` and `'` before including them in prompts. Error responses are recursively redacted: keys such as `token`, `password`, `secret`, `apiKey` and other credential-like fields—or string values that match those patterns or appear base64-encoded—are replaced with `[REDACTED]`. Redaction patterns are currently hardcoded in [`lib/security.ts`](./lib/security.ts) and can be customized there if needed.
+Review and update these patterns regularly to catch newly emerging sensitive data types.
 
 ## Reasoning models and context management
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ VITE_CIPHER_SERVER_URL=http://localhost:3000
 
 If the server is not running, HeavyOrc continues to operate with ephemeral in-memory history. Cipher speaks the Model Context Protocol, so the same memory store can be shared with other tools in the future.
 
-Fetched memory snippets are HTML-escaped before being included in prompts, and error responses are recursively redacted so logs don't leak tokens, passwords, or other secrets.
+Fetched memory snippets are HTML-escaped with [`escape-html`](https://www.npmjs.com/package/escape-html), replacing characters like `&`, `<`, `>`, `"` and `'` before including them in prompts. Error responses are recursively redacted: keys such as `token`, `password`, `secret`, `apiKey` and other credential-like fields—or string values that match those patterns or appear base64-encoded—are replaced with `[REDACTED]`. Redaction patterns are currently hardcoded in [`lib/security.ts`](./lib/security.ts) and can be customized there if needed.
 
 ## Reasoning models and context management
 

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -45,9 +45,15 @@ function isSensitiveString(value: string): boolean {
  */
 function sanitize(data: unknown): unknown {
   if (Array.isArray(data)) {
-    return data.map(item =>
-      item && typeof item === 'object' ? sanitize(item) : '[REDACTED]'
-    );
+    return data.map(item => {
+      if (item && typeof item === 'object') {
+        return sanitize(item);
+      }
+      if (typeof item === 'string' && isSensitiveString(item)) {
+        return '[REDACTED]';
+      }
+      return item;
+    });
   }
 
   if (data && typeof data === 'object' && data !== null) {

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -45,15 +45,7 @@ function isSensitiveString(value: string): boolean {
  */
 function sanitize(data: unknown): unknown {
   if (Array.isArray(data)) {
-    return data.map(item => {
-      if (item && typeof item === 'object') {
-        return sanitize(item);
-      }
-      if (typeof item === 'string' && isSensitiveString(item)) {
-        return '[REDACTED]';
-      }
-      return item;
-    });
+    return data.map((item): unknown => sanitize(item));
   }
 
   if (data && typeof data === 'object' && data !== null) {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest';
+import { sanitizeErrorResponse } from '@/lib/security';
+
+describe('sanitizeErrorResponse arrays', () => {
+  test('retains non-sensitive array items', () => {
+    const input = JSON.stringify([1, 'alpha', true, null]);
+    const output = sanitizeErrorResponse(input);
+    expect(JSON.parse(output)).toEqual([1, 'alpha', true, null]);
+  });
+
+  test('redacts sensitive array items', () => {
+    const input = JSON.stringify(['token123', { password: 'secret' }]);
+    const output = sanitizeErrorResponse(input);
+    expect(JSON.parse(output)).toEqual(['[REDACTED]', { password: '[REDACTED]' }]);
+  });
+});

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -13,4 +13,16 @@ describe('sanitizeErrorResponse arrays', () => {
     const output = sanitizeErrorResponse(input);
     expect(JSON.parse(output)).toEqual(['[REDACTED]', { password: '[REDACTED]' }]);
   });
+
+  test('handles nested arrays and mixed data', () => {
+    const input = JSON.stringify([
+      ['safe', 'token123', ['nested_password']],
+      { safe: 'value', sensitive: 'apiKey123' },
+    ]);
+    const output = sanitizeErrorResponse(input);
+    expect(JSON.parse(output)).toEqual([
+      ['safe', '[REDACTED]', ['[REDACTED]']],
+      { safe: 'value', sensitive: '[REDACTED]' },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- avoid redacting non-sensitive values when sanitizing arrays
- document HTML escaping and redaction patterns
- cover array sanitization with tests

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5f984030c8322be0d0abd824a8559