### PR TITLE
fix: surface memory persistence failures

### DIFF
--- a/services/cipherService.ts
+++ b/services/cipherService.ts
@@ -102,11 +102,11 @@ export const storeRunRecord = async (run: RunRecord): Promise<void> => {
 
       if (!allowsSelf) {
         console.error('Invalid or insufficient CSP headers from memory server');
-        return;
+        throw new Error('Invalid CSP headers');
       }
     } else {
       console.error('Missing CSP headers from memory server');
-      return;
+      throw new Error('Missing CSP headers');
     }
     if (!response.ok) {
       const errorData = await response.text().catch(() => 'Unable to read error response');
@@ -116,13 +116,14 @@ export const storeRunRecord = async (run: RunRecord): Promise<void> => {
         statusText: response.statusText,
         body: sanitizeErrorResponse(errorData),
       });
+      throw new Error('Failed to store run record');
     }
   } catch (e) {
     console.error('Failed to store run record', {
       url: `${baseUrl}/memories`,
       error: e,
     });
-    // Swallow errors to avoid breaking the app when memory is unreachable
+    throw e;
   }
 };
 

--- a/tests/cipherService.test.ts
+++ b/tests/cipherService.test.ts
@@ -96,6 +96,14 @@ describe('cipherService', () => {
     expect(res).toEqual([]);
   });
 
+  it('propagates network errors when storing run record', async () => {
+    vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
+    vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
+    global.fetch = vi.fn().mockRejectedValue(new Error('network')) as any;
+    const { storeRunRecord } = await import('@/services/cipherService');
+    await expect(storeRunRecord(sampleRun)).rejects.toThrow('network');
+  });
+
   it('redacts sensitive info in error responses', async () => {
     vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
     vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
@@ -123,7 +131,7 @@ describe('cipherService', () => {
     global.fetch = fetchMock as any;
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { storeRunRecord } = await import('@/services/cipherService');
-    await storeRunRecord(sampleRun);
+    await expect(storeRunRecord(sampleRun)).rejects.toThrow('Failed to store run record');
     const logged = consoleSpy.mock.calls[0][1] as any;
     expect(logged.body).toBe(
       '{"token":"[REDACTED]","Password":"[REDACTED]","certificate":"[REDACTED]","connection-string":"[REDACTED]","private_key":"[REDACTED]","session_id":"[REDACTED]","encoded":"[REDACTED]","shortEncoded":"[REDACTED]"}'
@@ -148,7 +156,7 @@ describe('cipherService', () => {
     global.fetch = fetchMock as any;
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { storeRunRecord } = await import('@/services/cipherService');
-    await storeRunRecord(sampleRun);
+    await expect(storeRunRecord(sampleRun)).rejects.toThrow('Failed to store run record');
     const logged = consoleSpy.mock.calls[0][1] as any;
     expect(logged.body).toBe('[{"token":"[REDACTED]"},"[REDACTED]"]');
     consoleSpy.mockRestore();
@@ -177,7 +185,7 @@ describe('cipherService', () => {
     global.fetch = fetchMock as any;
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { storeRunRecord } = await import('@/services/cipherService');
-    await storeRunRecord(sampleRun);
+    await expect(storeRunRecord(sampleRun)).rejects.toThrow('Failed to store run record');
     const logged = consoleSpy.mock.calls[0][1] as any;
     expect(logged.body).toBe('{"details":{"token":"[REDACTED]","items":["[REDACTED]",{"password":"[REDACTED]"}]}}');
     consoleSpy.mockRestore();


### PR DESCRIPTION
## Summary
- throw on invalid/missing CSP or failed responses in cipher memory persistence
- rethrow underlying errors so App can notify users
- test storeRunRecord rejection paths and network failures

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b5ff1d982c8322a4c0f5a978992498