### PR TITLE
fix: make cipher CSP check optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,5 @@ VITE_APP_URL=https://your-domain.example
 # Persistent memory (Cipher)
 VITE_USE_CIPHER_MEMORY=false
 VITE_CIPHER_SERVER_URL=http://localhost:3000
+# Optional: enforce CSP headers from the memory server
+VITE_ENFORCE_CIPHER_CSP=false

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The server defaults to an in-memory vector store (`VECTOR_STORE_TYPE=in-memory`)
 ```env
 VITE_USE_CIPHER_MEMORY=true
 VITE_CIPHER_SERVER_URL=http://localhost:3000
+# Optionally enforce Content-Security-Policy headers from the memory server
+# Set this only if the server exposes "Content-Security-Policy" via CORS
+# (see Access-Control-Expose-Headers)
+VITE_ENFORCE_CIPHER_CSP=false
 ```
 
 If the server is not running, HeavyOrc continues to operate with ephemeral in-memory history. Cipher speaks the Model Context Protocol, so the same memory store can be shared with other tools in the future.

--- a/services/cipherService.ts
+++ b/services/cipherService.ts
@@ -10,6 +10,7 @@ export interface MemoryEntry {
 
 const useCipher = import.meta.env.VITE_USE_CIPHER_MEMORY === 'true';
 const baseUrl = validateUrl(import.meta.env.VITE_CIPHER_SERVER_URL, import.meta.env.DEV);
+const enforceCsp = import.meta.env.VITE_ENFORCE_CIPHER_CSP === 'true';
 
 const RATE_LIMIT_WINDOW = 60000; // 1 minute
 const MAX_REQUESTS = 30; // 30 requests per minute
@@ -78,35 +79,37 @@ export const storeRunRecord = async (run: RunRecord): Promise<void> => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ run }),
     });
-    const csp = response.headers.get('Content-Security-Policy');
-    if (csp) {
-      type CSPDirective = { name: string; sources: string[] };
+    if (enforceCsp) {
+      const csp = response.headers.get('Content-Security-Policy');
+      if (csp) {
+        type CSPDirective = { name: string; sources: string[] };
 
-      const parseDirective = (directive: string): CSPDirective => {
-        const [name, ...sources] = directive.trim().split(/\s+/);
-        return { name, sources };
-      };
+        const parseDirective = (directive: string): CSPDirective => {
+          const [name, ...sources] = directive.trim().split(/\s+/);
+          return { name, sources };
+        };
 
-      const directives = csp
-        .split(';')
-        .map(d => d.trim())
-        .filter(Boolean)
-        .map(parseDirective)
-        .filter(d => d.name && d.sources.length > 0);
+        const directives = csp
+          .split(';')
+          .map(d => d.trim())
+          .filter(Boolean)
+          .map(parseDirective)
+          .filter(d => d.name && d.sources.length > 0);
 
-      const allowsSelf = directives.some(
-        d =>
-          (d.name === 'connect-src' || d.name === 'default-src') &&
-          d.sources.includes("'self'")
-      );
+        const allowsSelf = directives.some(
+          d =>
+            (d.name === 'connect-src' || d.name === 'default-src') &&
+            d.sources.includes("'self'")
+        );
 
-      if (!allowsSelf) {
-        console.error('Invalid or insufficient CSP headers from memory server');
-        throw new Error('Invalid CSP headers');
+        if (!allowsSelf) {
+          console.error('Invalid or insufficient CSP headers from memory server');
+          throw new Error('Invalid CSP headers');
+        }
+      } else {
+        console.error('Missing CSP headers from memory server');
+        throw new Error('Missing CSP headers');
       }
-    } else {
-      console.error('Missing CSP headers from memory server');
-      throw new Error('Missing CSP headers');
     }
     if (!response.ok) {
       const errorData = await response.text().catch(() => 'Unable to read error response');

--- a/tests/cipherService.test.ts
+++ b/tests/cipherService.test.ts
@@ -30,14 +30,21 @@ describe('cipherService', () => {
   it('stores run record when enabled', async () => {
     vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
     vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
-    const headers = {
-      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src 'self'",
-    };
-    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200, headers }));
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
     global.fetch = fetchMock as any;
     const { storeRunRecord } = await import('@/services/cipherService');
     await storeRunRecord(sampleRun);
     expect(fetchMock).toHaveBeenCalledWith('http://cipher/memories', expect.any(Object));
+  });
+
+  it('optionally enforces CSP headers', async () => {
+    vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
+    vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
+    vi.stubEnv('VITE_ENFORCE_CIPHER_CSP', 'true');
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    global.fetch = fetchMock as any;
+    const { storeRunRecord } = await import('@/services/cipherService');
+    await expect(storeRunRecord(sampleRun)).rejects.toThrow('Missing CSP headers');
   });
 
   it('skips storing run record when an agent content exceeds limit', async () => {


### PR DESCRIPTION
## Summary
- make Content-Security-Policy enforcement optional for Cipher memory
- document `VITE_ENFORCE_CIPHER_CSP`
- add test covering optional CSP enforcement

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b602924cb48322aae604d90614345b