### PR TITLE
fix: load service worker relative to base

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       <script type="module">
         window.__SW_VERSION__ = import.meta.env.VITE_SW_VERSION;
       </script>
-      <script type="module" src="/coi-serviceworker.js"></script>
+      <script src="%BASE_URL%coi-serviceworker.js"></script>
     <style>
       html {
         box-sizing: border-box;

--- a/index.html
+++ b/index.html
@@ -27,10 +27,12 @@
         window.__SW_VERSION__ = import.meta.env.VITE_SW_VERSION;
       </script>
       <script type="module">
-        const base = window.location.origin + import.meta.env.BASE_URL;
-        import(/* @vite-ignore */ `${base}coi-serviceworker.js`).catch((error) => {
-          console.error('Failed to load service worker:', error);
-        });
+        const base = new URL(import.meta.env.BASE_URL, window.location.origin);
+        import(/* @vite-ignore */ new URL('coi-serviceworker.js', base).href).catch(
+          (error) => {
+            console.error('Failed to load service worker:', error);
+          }
+        );
       </script>
     <style>
       html {

--- a/index.html
+++ b/index.html
@@ -26,7 +26,9 @@
       <script type="module">
         window.__SW_VERSION__ = import.meta.env.VITE_SW_VERSION;
       </script>
-      <script src="%BASE_URL%coi-serviceworker.js"></script>
+      <script type="module">
+        import(/* @vite-ignore */ `%BASE_URL%` + 'coi-serviceworker.js');
+      </script>
     <style>
       html {
         box-sizing: border-box;

--- a/index.html
+++ b/index.html
@@ -27,10 +27,15 @@
         window.__SW_VERSION__ = import.meta.env.VITE_SW_VERSION;
       </script>
       <script type="module">
-        const base = new URL(import.meta.env.BASE_URL, window.location.origin);
+        /** @type {URL} */
+        let base = new URL(import.meta.env.BASE_URL, window.location.origin);
+        if (base.origin !== window.location.origin) {
+          base = new URL(base.pathname, window.location.origin);
+        }
         import(/* @vite-ignore */ new URL('coi-serviceworker.js', base).href).catch(
           (error) => {
             console.error('Failed to load service worker:', error);
+            alert('Failed to load the service worker; cross-origin isolation is disabled.');
           }
         );
       </script>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,10 @@
         window.__SW_VERSION__ = import.meta.env.VITE_SW_VERSION;
       </script>
       <script type="module">
-        import(/* @vite-ignore */ `%BASE_URL%` + 'coi-serviceworker.js');
+        const base = window.location.origin + import.meta.env.BASE_URL;
+        import(/* @vite-ignore */ `${base}coi-serviceworker.js`).catch((error) => {
+          console.error('Failed to load service worker:', error);
+        });
       </script>
     <style>
       html {


### PR DESCRIPTION
## Summary
- reference COOP/COEP service worker using the app's base URL

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b718e975dc832299e8b5dcf7ce4df5