### PR TITLE
fix: skip cache shrink when quota unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Review and update these patterns regularly to catch newly emerging sensitive dat
 
 Memory requests are rate-limited to 30 per minute, cap each entry at 4KB and limit total response size to 400KB. Successful responses are cached for five minutes (up to 1000 entries) using a min-heap for eviction. All fetches use the shared retry helpers and honor standard timeouts. A circuit breaker skips memory fetches after five consecutive failures and resets after 30 seconds. Tune these thresholds via `VITE_CIPHER_CIRCUIT_BREAKER_THRESHOLD` and `VITE_CIPHER_CIRCUIT_BREAKER_RESET_MS`.
 
+The in-browser session cache keeps up to 20 messages per conversation and prunes entries older than the configured TTL. When `navigator.storage.estimate` reports storage usage above 90% of the available quota, the cache reduces its maximum size by 25% to relieve pressure. Browsers without this API skip the shrink step to preserve context.
+
 ## ESM imports
 
 `index.html` uses an import map to pin CDN-hosted ESM bundles to exact versions. When upgrading these dependencies, update the URLs in the map and verify the new files before deployment. For additional hardening, consider hosting vetted copies under `public/vendor` and updating the map to point to those local assets if the CDN becomes unavailable.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Review and update these patterns regularly to catch newly emerging sensitive dat
 
 Memory requests are rate-limited to 30 per minute, cap each entry at 4KB and limit total response size to 400KB. Successful responses are cached for five minutes (up to 1000 entries) using a min-heap for eviction. All fetches use the shared retry helpers and honor standard timeouts. A circuit breaker skips memory fetches after five consecutive failures and resets after 30 seconds. Tune these thresholds via `VITE_CIPHER_CIRCUIT_BREAKER_THRESHOLD` and `VITE_CIPHER_CIRCUIT_BREAKER_RESET_MS`.
 
-The in-browser session cache keeps up to 20 messages per conversation and prunes entries older than the configured TTL. When `navigator.storage.estimate` reports storage usage above 90% of the available quota, the cache reduces its maximum size by 25% to relieve pressure. Browsers without this API skip the shrink step to preserve context.
+The in-browser session cache keeps up to 20 messages per conversation and prunes entries older than the configured TTL. When `navigator.storage.estimate` reports storage usage above 90% of the available quota (`MEMORY_PRESSURE_THRESHOLD`), the cache reduces its maximum size by 25% to relieve pressure. Browsers without this API skip the shrink step to preserve context.
 
 ## ESM imports
 

--- a/lib/sessionCache.ts
+++ b/lib/sessionCache.ts
@@ -49,12 +49,12 @@ function detectCacheLeak(): void {
 
 function checkStorageQuota(): Promise<number> {
   if (typeof navigator === 'undefined' || !(navigator as any).storage?.estimate) {
-    return Promise.resolve(1);
+    return Promise.resolve(0);
   }
   return (navigator as any).storage
     .estimate()
-    .then(({ usage, quota }: any) => (usage && quota ? usage / quota : 1))
-    .catch(() => 1);
+    .then(({ usage, quota }: any) => (usage && quota ? usage / quota : 0))
+    .catch(() => 0);
 }
 
 async function adjustCacheSize(): Promise<void> {

--- a/lib/sessionCache.ts
+++ b/lib/sessionCache.ts
@@ -47,13 +47,15 @@ function detectCacheLeak(): void {
   }
 }
 
+type StorageEstimateResult = { usage?: number; quota?: number };
+
 function checkStorageQuota(): Promise<number> {
   if (typeof navigator === 'undefined' || !(navigator as any).storage?.estimate) {
     return Promise.resolve(0);
   }
   return (navigator as any).storage
     .estimate()
-    .then(({ usage, quota }: any) => (usage && quota ? usage / quota : 0))
+    .then(({ usage, quota }: StorageEstimateResult) => (usage && quota ? usage / quota : 0))
     .catch(() => 0);
 }
 

--- a/tests/sessionCache.test.ts
+++ b/tests/sessionCache.test.ts
@@ -348,4 +348,16 @@ describe('sessionCache', () => {
     await __adjustCacheSize();
     expect(__getMaxEntries()).toBeLessThan(SESSION_CACHE_MAX_ENTRIES);
   });
+
+  it('skips cache shrink when quota is unknown', async () => {
+    const sessionId = 'noquota';
+    appendSessionContext(sessionId, {
+      role: 'user',
+      content: 'm',
+      timestamp: Date.now(),
+    });
+    (globalThis as any).navigator = {};
+    await __adjustCacheSize();
+    expect(__getMaxEntries()).toBe(SESSION_CACHE_MAX_ENTRIES);
+  });
 });


### PR DESCRIPTION
## Summary
- avoid shrinking session cache when browser storage quota is unknown
- document session cache cleanup behavior
- test cache shrink behavior for missing quota API

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b785121e108322b616c30593a02ab1