### PR TITLE
fix: store raw user prompt in run records

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -312,6 +312,7 @@ const App: React.FC = () => {
                     id: `${Date.now()}`,
                     timestamp: Date.now(),
                     ...currentRunDataRef.current,
+                    prompt: userPromptRef.current,
                     finalAnswer: finalAnswerRef.current,
                     agents: agentsRef.current,
                     status: finalStatus,
@@ -435,7 +436,7 @@ const App: React.FC = () => {
 
             isRunCompletedRef.current = false;
             currentRunDataRef.current = {
-                prompt: finalPrompt,
+                prompt: userPrompt,
                 images,
                 agentConfigs,
                 arbiterModel,


### PR DESCRIPTION
## Summary
- persist original user prompt instead of context-expanded prompt when storing run records

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b79db001f88322bb6c308acc0673cc