### PR TITLE
fix: persist initial run and internalize IP lookup

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -302,7 +302,7 @@ const App: React.FC = () => {
     }, []);
 
     useEffect(() => {
-        if (!isLoading && isRunCompletedRef.current) {
+        if (!isLoading && isRunCompletedRef.current && sessionIdRef.current) {
             isRunCompletedRef.current = false; // Reset for next run
 
             const finalStatus: RunStatus = errorRef.current ? 'FAILED' : 'COMPLETED';
@@ -339,7 +339,7 @@ const App: React.FC = () => {
                 currentRunDataRef.current = undefined; // Clear after use
             }
         }
-    }, [isLoading]);
+    }, [isLoading, sessionId, appendSession]);
 
 
     useEffect(() => {

--- a/services/cipherService.ts
+++ b/services/cipherService.ts
@@ -105,10 +105,10 @@ async function getClientIp(): Promise<string | null> {
     clientIpPromise = Promise.resolve((globalThis as any).__TEST_IP__);
     return clientIpPromise;
   }
-  if (typeof fetch === 'undefined') return null;
-  clientIpPromise = fetch('https://api.ipify.org?format=json')
+  if (typeof fetch === 'undefined' || !baseUrl) return null;
+  clientIpPromise = fetch(`${baseUrl}/api/client-info`)
     .then(r => r.json())
-    .then(d => d.ip as string)
+    .then(d => d.clientIp as string)
     .catch(() => null);
   const ip = await clientIpPromise;
   clientIpPromise = Promise.resolve(ip);


### PR DESCRIPTION
## Summary
- ensure session cache writes wait for a resolved session id
- replace third-party IP lookup with internal `/api/client-info`

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b7dc2920688322a7db970ad3a819f0