### PR TITLE
fix: harden security and rate limiting

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,16 @@
     "framer-motion": "https://esm.sh/framer-motion@11.3.12",
     "@vitejs/plugin-react": "https://esm.sh/@vitejs/plugin-react@5.0.1",
     "vite": "https://esm.sh/vite@7.1.3"
+  },
+  "integrity": {
+    "react": "sha384-Ogra4B4/U/4iEtCyk0Yj6gil3tZXoNnC4H9n/2/5H3RCyayDxiJfbLb9gn53qHz8",
+    "react-dom/client": "sha384-LH9ZXoznLvlL5CYFmmG9UYGhNWqn603BK4OF/2NOPQ+ep8ikg4It8tvFnSlfTj5E",
+    "@google/genai": "sha384-ZV/sXFXC9HxS6DCnxAeUQC5pILO54odwCXc9N0mir1EuCPkJP1Xbr5YWLZi71530",
+    "openai": "sha384-Yswg1EyBmR6TV1153X2DhePMwNhRMyEDmiqXXuHYHuP82VJIn6SoEUZ8IWPTXwVA",
+    "jszip": "sha384-5yu53KesTlgYyfWOxjtPG0ma7N94YLbqMrj+ly/X+29t3zR/VnsuroiXiNxwlXZL",
+    "framer-motion": "sha384-ws8z3Z+X379/i3ZJG39kKEBOlySPnIa/bYBMImWynkHNfWOfRNbfO8gNJJiPlYP8",
+    "@vitejs/plugin-react": "sha384-z2xCfI36a5yZcX0atp2KNPfJiWCaep4wZz02ftiCv85wOGqbYwmsyF11cYOFBgZu",
+    "vite": "sha384-YTau6wAcV4+CO9E/6v35I0R6hQo02IV2qkJWi7RSE+Hqp7X9robJxf0qs6tydZ+p"
   }
 }
 </script>

--- a/lib/contextBuilder.ts
+++ b/lib/contextBuilder.ts
@@ -18,14 +18,17 @@ export function createDefaultSummarizer(maxLength = SUMMARIZER_MAX_CHARS): Summa
   return async (text: string): Promise<string> => {
     if (!text) return '';
     try {
-      const truncated = text.slice(0, maxLength);
-      const match = truncated.match(/.*[.!?]['")\s]*/s);
-      if (match) return match[0].trim();
+      const normalized = text.replace(/\s+/g, ' ').trim();
+      if (normalized.length <= maxLength) return normalized;
+      const truncated = normalized.slice(0, maxLength);
+      const sentenceMatch = truncated.match(/.*[.!?]['")}\]]?(?:\s|$)/s);
+      if (sentenceMatch) return sentenceMatch[0].trim();
       const wordMatch = truncated.match(/.*\b/);
-      return (wordMatch ? wordMatch[0] : truncated).trim() + (text.length > maxLength ? '…' : '');
+      if (wordMatch) return wordMatch[0].trim() + '…';
+      return truncated.trim() + '…';
     } catch (e) {
       console.warn('Error in summarizer:', e);
-      return text.slice(0, maxLength) + '…';
+      return text.slice(0, maxLength).trim() + '…';
     }
   };
 }

--- a/lib/contextBuilder.ts
+++ b/lib/contextBuilder.ts
@@ -18,7 +18,10 @@ export function createDefaultSummarizer(maxLength = SUMMARIZER_MAX_CHARS): Summa
   return async (text: string): Promise<string> => {
     if (!text) return '';
     try {
-      const normalized = text.replace(/\s+/g, ' ').trim();
+      const normalized = text
+        .slice(0, maxLength * 2)
+        .replace(/\s+/g, ' ')
+        .trim();
       if (normalized.length <= maxLength) return normalized;
       const truncated = normalized.slice(0, maxLength);
       const sentenceMatch = truncated.match(/.*[.!?]['")}\]]?(?:\s|$)/s);

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -125,20 +125,34 @@ export function sanitizeErrorResponse(body: string): string {
 
 function isPrivateOrLocalhost(hostname: string): boolean {
   const host = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
-  if (host === 'localhost') return true;
+  if (host === 'localhost' || /^localhost\./i.test(host)) return true;
   if (ipaddr.isValid(host)) {
     let parsed = ipaddr.parse(host);
     if (parsed.kind() === 'ipv6') {
       const ipv6 = parsed as ipaddr.IPv6;
-      if (host.includes('%')) return true;
+      if (host.includes('%')) return true; // Block zone IDs
       if (ipv6.isIPv4MappedAddress()) {
         parsed = ipv6.toIPv4Address();
       }
     }
     const range = parsed.range();
-    return ['loopback', 'linkLocal', 'uniqueLocal', 'private', 'unspecified'].includes(range);
+    return [
+      'loopback',
+      'linkLocal',
+      'uniqueLocal',
+      'private',
+      'unspecified',
+      'broadcast',
+      'multicast',
+    ].includes(range);
   }
-  return false;
+  // Block DNS rebinding or obfuscated IP forms
+  return (
+    /\d+\.\d+\.\d+\.\d+/.test(host) || // Dotted decimal
+    /^0x[0-9a-f]+$/i.test(host) || // Hexadecimal
+    /^[0-7]+$/.test(host) || // Octal
+    /^\d+$/.test(host) // Decimal integer
+  );
 }
 
 export function validateUrl(
@@ -251,6 +265,7 @@ export function validateCsp(response: Response): void {
       s =>
         s === "'unsafe-inline'" ||
         s === "'unsafe-eval'" ||
+        s === "'unsafe-hashes'" ||
         s === '*'
     )
   );

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -148,7 +148,7 @@ function isPrivateOrLocalhost(hostname: string): boolean {
   }
   // Block DNS rebinding or obfuscated IP forms
   return (
-    /\d+\.\d+\.\d+\.\d+/.test(host) || // Dotted decimal
+    /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?\d\d?)$/.test(host) || // Dotted decimal
     /^0x[0-9a-f]+$/i.test(host) || // Hexadecimal
     /^[0-7]+$/.test(host) || // Octal
     /^\d+$/.test(host) // Decimal integer

--- a/lib/sessionCache.ts
+++ b/lib/sessionCache.ts
@@ -93,10 +93,18 @@ function pruneSession(sessionId: string): void {
 
 async function signSessionId(id: string): Promise<string> {
   const encoder = new TextEncoder();
-  const data = encoder.encode(id + SESSION_ID_SECRET);
-  const hash = await crypto.subtle.digest('SHA-256', data);
-  const hashArray = Array.from(new Uint8Array(hash));
-  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  const keyData = encoder.encode(SESSION_ID_SECRET);
+  const key = await crypto.subtle.importKey(
+    'raw',
+    keyData,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(id));
+  return Array.from(new Uint8Array(signature))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
 }
 
 function isValidSessionId(id: string): boolean {

--- a/services/cipherService.ts
+++ b/services/cipherService.ts
@@ -305,25 +305,19 @@ export const fetchRelevantMemories = async (
         url: `${baseUrl}/memories/search`,
         error,
         errorType: error instanceof Error ? error.name : typeof error,
-        statusCode: error instanceof Response ? error.status : undefined,
       });
       recordFailure();
       logMemory('cipher.fetch.error', {
         sessionId,
-        query,
-        error,
         errorType: error instanceof Error ? error.name : typeof error,
-        recoverable: error instanceof Response && error.status >= 500,
+        recoverable:
+          error instanceof Error && /temporarily unavailable/i.test(error.message),
+        queryLength: query?.length,
       });
-      if (error instanceof Response && error.status >= 500) {
-        return [];
-      } else if (error instanceof TypeError) {
+      if (error instanceof TypeError) {
         console.warn('Network error while fetching memories - check connectivity');
-        return [];
-      } else {
-        console.error('Unexpected error type while fetching memories');
-        return [];
       }
+      return [];
     }
   })();
 

--- a/services/cipherService.ts
+++ b/services/cipherService.ts
@@ -30,6 +30,16 @@ let currentCacheSize = 0;
 const expiryHeap = new MinHeap<[string, number]>((a, b) => a[1] - b[1]);
 const inFlightFetches = new Map<string, Promise<MemoryEntry[]>>();
 
+class Mutex {
+  private mutex = Promise.resolve();
+  runExclusive<T>(fn: () => Promise<T> | T): Promise<T> {
+    const result = this.mutex.then(() => fn());
+    this.mutex = result.catch(() => {});
+    return result;
+  }
+}
+const rateLimitMutex = new Mutex();
+
 const CIRCUIT_BREAKER_THRESHOLD = Number(
   import.meta.env.VITE_CIPHER_CIRCUIT_BREAKER_THRESHOLD ?? 5,
 );
@@ -128,7 +138,7 @@ async function consumeToken(sessionId: string): Promise<boolean> {
   if (typeof navigator !== 'undefined' && 'locks' in navigator && navigator.locks) {
     return navigator.locks.request(`cipher-rate:${sessionId}`, exec);
   }
-  return exec();
+  return rateLimitMutex.runExclusive(() => Promise.resolve(exec()));
 }
 
 export const storeRunRecords = async (
@@ -290,14 +300,30 @@ export const fetchRelevantMemories = async (
       logMemory('cipher.fetch', { sessionId, query, count: memories.length });
       circuitBreaker.failures = 0;
       return memories;
-    } catch (e) {
+    } catch (error) {
       console.error('Failed to fetch relevant memories', {
         url: `${baseUrl}/memories/search`,
-        error: e,
+        error,
+        errorType: error instanceof Error ? error.name : typeof error,
+        statusCode: error instanceof Response ? error.status : undefined,
       });
       recordFailure();
-      logMemory('cipher.fetch.error', { sessionId, query, error: e });
-      return [];
+      logMemory('cipher.fetch.error', {
+        sessionId,
+        query,
+        error,
+        errorType: error instanceof Error ? error.name : typeof error,
+        recoverable: error instanceof Response && error.status >= 500,
+      });
+      if (error instanceof Response && error.status >= 500) {
+        return [];
+      } else if (error instanceof TypeError) {
+        console.warn('Network error while fetching memories - check connectivity');
+        return [];
+      } else {
+        console.error('Unexpected error type while fetching memories');
+        return [];
+      }
     }
   })();
 

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -50,6 +50,9 @@ describe('validateUrl', () => {
     expect(validateUrl('http://[fd00::1]', [], false)).toBeUndefined();
     expect(validateUrl('http://[fe80::1]', [], false)).toBeUndefined();
     expect(validateUrl('http://[fe80::1%eth0]', [], false)).toBeUndefined();
+    expect(validateUrl('http://0x7f000001', [], false)).toBeUndefined();
+    expect(validateUrl('http://017700000001', [], false)).toBeUndefined();
+    expect(validateUrl('http://2130706433', [], false)).toBeUndefined();
     expect(validateUrl('https://example.com', ['example.com'], false)).toBe('https://example.com');
     expect(validateUrl('https://evil.com', ['example.com'], false)).toBeUndefined();
     expect(validateUrl('https://example.com:8080', [], false)).toBe('https://example.com:8080');
@@ -80,6 +83,15 @@ describe('validateCsp', () => {
     const headers = new Headers({
       'Content-Security-Policy':
         "default-src 'none'; connect-src 'self'; object-src 'none'; base-uri 'none'; script-src 'none'; style-src *",
+    });
+    const response = new Response('', { headers });
+    expect(() => validateCsp(response)).toThrow('Invalid CSP headers');
+  });
+
+  test('rejects unsafe hashes', () => {
+    const headers = new Headers({
+      'Content-Security-Policy':
+        "default-src 'none'; connect-src 'self'; object-src 'none'; base-uri 'none'; script-src 'none' 'unsafe-hashes'; style-src 'none'",
     });
     const response = new Response('', { headers });
     expect(() => validateCsp(response)).toThrow('Invalid CSP headers');

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -53,6 +53,9 @@ describe('validateUrl', () => {
     expect(validateUrl('http://0x7f000001', [], false)).toBeUndefined();
     expect(validateUrl('http://017700000001', [], false)).toBeUndefined();
     expect(validateUrl('http://2130706433', [], false)).toBeUndefined();
+    expect(
+      validateUrl('https://subdomain.1.2.3.4.com', [], false),
+    ).toBe('https://subdomain.1.2.3.4.com');
     expect(validateUrl('https://example.com', ['example.com'], false)).toBe('https://example.com');
     expect(validateUrl('https://evil.com', ['example.com'], false)).toBeUndefined();
     expect(validateUrl('https://example.com:8080', [], false)).toBe('https://example.com:8080');


### PR DESCRIPTION
## Summary
- block more private network and obfuscated IP forms in URL validator
- catch unsafe-hashes in CSP headers and improve error handling
- use HMAC for session IDs and add mutex to rate limiter
- normalize summarizer and add SRI hashes for CDN imports

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b7e7cf1e888322b126c1c8680d6c6d