### PR TITLE
fix: tighten cache and security logic

### DIFF
--- a/components/MemoryErrorBoundary.tsx
+++ b/components/MemoryErrorBoundary.tsx
@@ -1,6 +1,16 @@
 import { Component, ReactNode } from 'react';
 
-const DefaultFallback = ({ error, onRetry }: { error: unknown; onRetry: () => void }) => (
+const MAX_RETRIES = 3;
+
+const DefaultFallback = ({
+  error,
+  onRetry,
+  canRetry,
+}: {
+  error: unknown;
+  onRetry: () => void;
+  canRetry: boolean;
+}) => (
   <div role="alert" className="p-4 text-sm text-red-600 space-y-2">
     <p>Something went wrong while loading memories.</p>
     {error ? (
@@ -8,9 +18,13 @@ const DefaultFallback = ({ error, onRetry }: { error: unknown; onRetry: () => vo
         {String(error)}
       </pre>
     ) : null}
-    <button onClick={onRetry} className="underline text-blue-600">
-      Retry
-    </button>
+    {canRetry ? (
+      <button onClick={onRetry} className="underline text-blue-600">
+        Retry
+      </button>
+    ) : (
+      <p className="text-xs">Retry limit reached</p>
+    )}
   </div>
 );
 
@@ -21,10 +35,11 @@ interface Props {
 interface State {
   hasError: boolean;
   error: unknown;
+  retries: number;
 }
 
 export default class MemoryErrorBoundary extends Component<Props, State> {
-  state: State = { hasError: false, error: null };
+  state: State = { hasError: false, error: null, retries: 0 };
 
   static getDerivedStateFromError(error: unknown): State {
     return { hasError: true, error };
@@ -35,13 +50,20 @@ export default class MemoryErrorBoundary extends Component<Props, State> {
   }
 
   private handleRetry = () => {
-    this.setState({ hasError: false, error: null });
+    this.setState(prev => ({ hasError: false, error: null, retries: prev.retries + 1 }));
   };
 
   render() {
     if (this.state.hasError) {
       if (this.props.fallback) return this.props.fallback;
-      return <DefaultFallback error={this.state.error} onRetry={this.handleRetry} />;
+      const canRetry = this.state.retries < MAX_RETRIES;
+      return (
+        <DefaultFallback
+          error={this.state.error}
+          onRetry={this.handleRetry}
+          canRetry={canRetry}
+        />
+      );
     }
     return this.props.children;
   }

--- a/lib/lruCache.ts
+++ b/lib/lruCache.ts
@@ -3,6 +3,9 @@ export class LRUCache<K, V> {
   private cache = new Map<K, V>();
 
   constructor(max: number) {
+    if (max <= 0) {
+      throw new Error('LRUCache max size must be a positive number.');
+    }
     this.max = max;
   }
 

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -172,12 +172,13 @@ export function validateUrl(
     }
     const bareHost = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
     const allowedProtocols = ['http:', 'https:'];
-    const allowedPorts = ['', '80', '443'];
+    const allowedPorts = new Set(['', '80', '443']);
+    const portStr = parsed.port || '';
     if (
       !allowedProtocols.includes(parsed.protocol) ||
       hostname.length > 255 ||
       (!ipaddr.isValid(bareHost) && !/^(?!-)[a-zA-Z0-9-]+(?<!-)(?:\.[a-zA-Z0-9-]+)*$/.test(bareHost)) ||
-      (!dev && (parsed.protocol !== 'https:' || isPrivateOrLocalhost(hostname) || (parsed.port && !allowedPorts.includes(parsed.port)))) ||
+      (!dev && (parsed.protocol !== 'https:' || isPrivateOrLocalhost(hostname) || !allowedPorts.has(portStr))) ||
       (allowedHosts.length > 0 && !allowedHosts.includes(hostname))
     ) {
       return undefined;

--- a/services/cipherService.ts
+++ b/services/cipherService.ts
@@ -41,6 +41,7 @@ const MAX_FREEZE_DEPTH = 100;
 
 const sessionBuckets = new Map<string, { tokens: number; lastRefill: number }>();
 const ipBuckets = new Map<string, { tokens: number; lastRefill: number }>();
+const invalidSessionBuckets = new Map<string, { tokens: number; lastRefill: number }>();
 let clientIpPromise: Promise<string | null> | null = null;
 
 type CachedMemoryData = {
@@ -70,6 +71,8 @@ const CIRCUIT_BREAKER_RESET_MS = Number(
   import.meta.env.VITE_CIPHER_CIRCUIT_BREAKER_RESET_MS ?? 30000,
 );
 
+const MAX_BACKOFF_FACTOR = 16;
+
 const circuitBreaker = {
   failures: 0,
   lastFailure: 0,
@@ -82,7 +85,10 @@ function recordFailure() {
   circuitBreaker.failures += 1;
   circuitBreaker.lastFailure = Date.now();
   if (circuitBreaker.failures >= circuitBreaker.threshold) {
-    circuitBreaker.backoffFactor = Math.min(circuitBreaker.backoffFactor * 2, 16);
+    circuitBreaker.backoffFactor = Math.min(
+      circuitBreaker.backoffFactor * 2,
+      MAX_BACKOFF_FACTOR,
+    );
     circuitBreaker.resetTimeMs = CIRCUIT_BREAKER_RESET_MS * circuitBreaker.backoffFactor;
   }
 }
@@ -236,6 +242,12 @@ export const storeRunRecords = async (
 ): Promise<void> => {
   if (!useCipher || !baseUrl || !validateUrl(baseUrl, allowedHosts)) return;
   if (!SESSION_ID_PATTERN.test(sessionId)) {
+    const ip = await getClientIp();
+    if (ip && !consumeFromBucket(invalidSessionBuckets, ip)) {
+      console.warn('Rate limit exceeded for invalid session attempts');
+      logMemory('cipher.store.invalidSessionRateLimit', { ip });
+      return;
+    }
     console.warn('Invalid sessionId format');
     logMemory('cipher.store.invalidSession', { sessionId });
     throw new Error('Invalid sessionId');


### PR DESCRIPTION
## Summary
- validate positive max in LRU cache constructor
- harden URL port handling and cap circuit breaker backoff
- rate limit invalid session IDs and add retry cap for memory error boundary

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b8cf955a148322a08ecacf9881bebc