### PR TITLE
fix: tighten cache and security logic

### DIFF
--- a/components/MemoryErrorBoundary.tsx
+++ b/components/MemoryErrorBoundary.tsx
@@ -41,7 +41,7 @@ interface State {
 export default class MemoryErrorBoundary extends Component<Props, State> {
   state: State = { hasError: false, error: null, retries: 0 };
 
-  static getDerivedStateFromError(error: unknown): State {
+  static getDerivedStateFromError(error: unknown): Partial<State> {
     return { hasError: true, error };
   }
 

--- a/lib/lruCache.ts
+++ b/lib/lruCache.ts
@@ -1,10 +1,14 @@
+const MAX_CACHE_SIZE = 1_000_000;
+
 export class LRUCache<K, V> {
   private max: number;
   private cache = new Map<K, V>();
 
   constructor(max: number) {
-    if (!Number.isInteger(max) || max <= 0) {
-      throw new Error('LRUCache max size must be a positive integer.');
+    if (!Number.isInteger(max) || max <= 0 || max > MAX_CACHE_SIZE) {
+      throw new Error(
+        `LRUCache max size must be a positive integer not exceeding ${MAX_CACHE_SIZE}.`,
+      );
     }
     this.max = max;
   }

--- a/lib/lruCache.ts
+++ b/lib/lruCache.ts
@@ -3,8 +3,8 @@ export class LRUCache<K, V> {
   private cache = new Map<K, V>();
 
   constructor(max: number) {
-    if (max <= 0) {
-      throw new Error('LRUCache max size must be a positive number.');
+    if (!Number.isInteger(max) || max <= 0) {
+      throw new Error('LRUCache max size must be a positive integer.');
     }
     this.max = max;
   }

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -172,7 +172,7 @@ export function validateUrl(
     }
     const bareHost = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
     const allowedProtocols = ['http:', 'https:'];
-    const allowedPorts = new Set(['', '80', '443']);
+    const allowedPorts = Object.freeze(new Set(['', '80', '443']));
     const portStr = parsed.port || '';
     if (
       !allowedProtocols.includes(parsed.protocol) ||

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -171,14 +171,15 @@ export function validateUrl(
       }
     }
     const bareHost = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
-    const allowedProtocols = ['http:', 'https:'];
-    const allowedPorts = Object.freeze(new Set(['', '80', '443']));
+    const allowedProtocols = Object.freeze(['http:', 'https:'] as const);
+    const allowedPorts = Object.freeze(['', '80', '443'] as const);
+    const allowedPortSet = new Set(allowedPorts);
     const portStr = parsed.port || '';
     if (
       !allowedProtocols.includes(parsed.protocol) ||
       hostname.length > 255 ||
       (!ipaddr.isValid(bareHost) && !/^(?!-)[a-zA-Z0-9-]+(?<!-)(?:\.[a-zA-Z0-9-]+)*$/.test(bareHost)) ||
-      (!dev && (parsed.protocol !== 'https:' || isPrivateOrLocalhost(hostname) || !allowedPorts.has(portStr))) ||
+      (!dev && (parsed.protocol !== 'https:' || isPrivateOrLocalhost(hostname) || !allowedPortSet.has(portStr))) ||
       (allowedHosts.length > 0 && !allowedHosts.includes(hostname))
     ) {
       return undefined;

--- a/services/cipherService.ts
+++ b/services/cipherService.ts
@@ -71,9 +71,12 @@ const CIRCUIT_BREAKER_RESET_MS = Number(
   import.meta.env.VITE_CIPHER_CIRCUIT_BREAKER_RESET_MS ?? 30000,
 );
 
-const MAX_BACKOFF_FACTOR = Number(
-  import.meta.env.VITE_CIPHER_MAX_BACKOFF_FACTOR ?? 16,
+const MAX_BACKOFF_FACTOR = Math.min(
+  Math.max(Number(import.meta.env.VITE_CIPHER_MAX_BACKOFF_FACTOR ?? 16), 1),
+  32,
 );
+
+const INVALID_SESSION_DELAY_MS = 1000;
 
 const circuitBreaker = {
   failures: 0,
@@ -248,7 +251,8 @@ export const storeRunRecords = async (
     if (ip && !consumeFromBucket(invalidSessionBuckets, ip)) {
       console.warn('Rate limit exceeded for invalid session attempts');
       logMemory('cipher.store.invalidSessionRateLimit', { ip });
-      await new Promise(res => setTimeout(res, 1000));
+      const delay = INVALID_SESSION_DELAY_MS * (0.5 + Math.random());
+      await new Promise(res => setTimeout(res, delay));
       throw new Error('Rate limit exceeded for invalid session attempts');
     }
     console.warn('Invalid sessionId format');

--- a/services/cipherService.ts
+++ b/services/cipherService.ts
@@ -71,7 +71,9 @@ const CIRCUIT_BREAKER_RESET_MS = Number(
   import.meta.env.VITE_CIPHER_CIRCUIT_BREAKER_RESET_MS ?? 30000,
 );
 
-const MAX_BACKOFF_FACTOR = 16;
+const MAX_BACKOFF_FACTOR = Number(
+  import.meta.env.VITE_CIPHER_MAX_BACKOFF_FACTOR ?? 16,
+);
 
 const circuitBreaker = {
   failures: 0,
@@ -246,7 +248,8 @@ export const storeRunRecords = async (
     if (ip && !consumeFromBucket(invalidSessionBuckets, ip)) {
       console.warn('Rate limit exceeded for invalid session attempts');
       logMemory('cipher.store.invalidSessionRateLimit', { ip });
-      return;
+      await new Promise(res => setTimeout(res, 1000));
+      throw new Error('Rate limit exceeded for invalid session attempts');
     }
     console.warn('Invalid sessionId format');
     logMemory('cipher.store.invalidSession', { sessionId });


### PR DESCRIPTION
## Summary
- validate integer max in LRU cache constructor
- freeze allowed ports set for URL validation
- expose circuit breaker backoff factor via env variable
- ensure error boundary derives partial state and preserve retries
- throw on rate-limited invalid sessions and add delay

## Testing
- `npm test -- --run` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d1ac81d88322b324431c6dc102f1