### PR TITLE
fix: harden cache and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For a detailed, AI-oriented overview of the architecture and tooling, see the [S
 - **DeepConf**: confidence-driven generation modes (offline, online and judge-assisted).
 - **Streaming UI**: live progress bar and gallery of expert drafts.
 - **Session tools**: save and reload conversations or export all drafts as a ZIP.
+- **Adaptive cache**: monitors memory pressure and tunes eviction to protect critical data.
 
 ## Providers & API keys
 

--- a/constants.ts
+++ b/constants.ts
@@ -13,6 +13,116 @@ Instructions:
 7.  Ensure your final answer directly and thoroughly addresses the original user's question.
 8.  Do not include headings like "Final Answer" or "Synthesized Response". Begin the response directly.`;
 
+export enum ErrorSeverity {
+  CRITICAL = 'CRITICAL',
+  HIGH = 'HIGH',
+  MEDIUM = 'MEDIUM',
+  LOW = 'LOW',
+  INFO = 'INFO',
+}
+
+export enum ErrorCategory {
+  SECURITY = 'SECURITY',
+  VALIDATION = 'VALIDATION',
+  RATE_LIMIT = 'RATE_LIMIT',
+  SYSTEM = 'SYSTEM',
+}
+
+export interface ErrorCodeMetaData {
+  code: string;
+  severity: ErrorSeverity;
+  category: ErrorCategory;
+}
+
+export const ERROR_CODES = {
+  EMPTY_PROMPT: {
+    code: 'ERR_EMPTY_PROMPT',
+    severity: ErrorSeverity.LOW,
+    category: ErrorCategory.VALIDATION,
+  },
+  OPENAI_API_KEY_MISSING: {
+    code: 'ERR_OPENAI_KEY_MISSING',
+    severity: ErrorSeverity.HIGH,
+    category: ErrorCategory.VALIDATION,
+  },
+  OPENROUTER_API_KEY_MISSING: {
+    code: 'ERR_OPENROUTER_KEY_MISSING',
+    severity: ErrorSeverity.HIGH,
+    category: ErrorCategory.VALIDATION,
+  },
+  INVALID_SESSION_ID: {
+    code: 'ERR_INVALID_SESSION',
+    severity: ErrorSeverity.HIGH,
+    category: ErrorCategory.SECURITY,
+  },
+  RATE_LIMIT_EXCEEDED: {
+    code: 'ERR_RATE_LIMIT',
+    severity: ErrorSeverity.MEDIUM,
+    category: ErrorCategory.RATE_LIMIT,
+  },
+  NETWORK_ERROR: {
+    code: 'ERR_NETWORK',
+    severity: ErrorSeverity.HIGH,
+    category: ErrorCategory.SYSTEM,
+  },
+  SERVER_ERROR: {
+    code: 'ERR_SERVER',
+    severity: ErrorSeverity.HIGH,
+    category: ErrorCategory.SYSTEM,
+  },
+  UNAUTHORIZED: {
+    code: 'ERR_UNAUTHORIZED',
+    severity: ErrorSeverity.HIGH,
+    category: ErrorCategory.SECURITY,
+  },
+  FORBIDDEN: {
+    code: 'ERR_FORBIDDEN',
+    severity: ErrorSeverity.HIGH,
+    category: ErrorCategory.SECURITY,
+  },
+  TIMEOUT: {
+    code: 'ERR_TIMEOUT',
+    severity: ErrorSeverity.MEDIUM,
+    category: ErrorCategory.SYSTEM,
+  },
+  CONNECTION_REFUSED: {
+    code: 'ERR_CONNECTION_REFUSED',
+    severity: ErrorSeverity.HIGH,
+    category: ErrorCategory.SYSTEM,
+  },
+  DNS_FAILURE: {
+    code: 'ERR_DNS_FAILURE',
+    severity: ErrorSeverity.HIGH,
+    category: ErrorCategory.SYSTEM,
+  },
+} as const;
+
+export const ERRORS = {
+  [ERROR_CODES.EMPTY_PROMPT.code]:
+    'A user prompt is required to process this request. Please provide non-empty prompt text.',
+  [ERROR_CODES.OPENAI_API_KEY_MISSING.code]:
+    'Please set your OpenAI API key in the settings to use OpenAI models.',
+  [ERROR_CODES.OPENROUTER_API_KEY_MISSING.code]:
+    'Please set your OpenRouter API key in the settings to use OpenRouter models.',
+  [ERROR_CODES.INVALID_SESSION_ID.code]:
+    'Invalid session identifier format - expected UUID v4 like 123e4567-e89b-12d3-a456-426614174000',
+  [ERROR_CODES.RATE_LIMIT_EXCEEDED.code]:
+    'Rate limit exceeded. Please try again later.',
+  [ERROR_CODES.NETWORK_ERROR.code]:
+    'Network error occurred. Please check your connection.',
+  [ERROR_CODES.SERVER_ERROR.code]:
+    'Server error occurred. Please try again later.',
+  [ERROR_CODES.UNAUTHORIZED.code]:
+    'Authentication required to perform this action.',
+  [ERROR_CODES.FORBIDDEN.code]:
+    'You do not have permission to perform this action.',
+  [ERROR_CODES.TIMEOUT.code]: 'Request timed out. Please try again.',
+  [ERROR_CODES.CONNECTION_REFUSED.code]:
+    'Unable to connect to server. Please check your connection.',
+  [ERROR_CODES.DNS_FAILURE.code]:
+    'Unable to resolve server address. Please check your network settings.',
+} as const;
+
 export const SESSION_ID_STORAGE_KEY = 'cipher:sessionId';
 export const SESSION_CACHE_MAX_ENTRIES = 20;
 export const SESSION_CACHE_MAX_SESSIONS = 100;
@@ -38,7 +148,28 @@ if (SESSION_ID_SECRET === 'dev-session-secret') {
 }
 
 // Cache tuning
-export const MEMORY_PRESSURE_THRESHOLD = 0.9; // 90% of available storage
+const envNumber = (key: string, viteKey: string, fallback: number): number => {
+  const v =
+    (typeof process !== 'undefined' && process.env[key]) ||
+    (typeof import.meta !== 'undefined' && (import.meta as any).env?.[viteKey]);
+  return v ? Number(v) : fallback;
+};
+
+export const MEMORY_PRESSURE_THRESHOLD = envNumber(
+  'MEMORY_PRESSURE_THRESHOLD',
+  'VITE_MEMORY_PRESSURE_THRESHOLD',
+  0.9,
+); // 90% of available storage
+export const MEMORY_PRESSURE_EVICT_RATIO = envNumber(
+  'MEMORY_PRESSURE_EVICT_RATIO',
+  'VITE_MEMORY_PRESSURE_EVICT_RATIO',
+  0.5,
+); // evict 50% of entries
+export const MEMORY_PRESSURE_CHECK_INTERVAL = envNumber(
+  'MEMORY_PRESSURE_CHECK_INTERVAL',
+  'VITE_MEMORY_PRESSURE_CHECK_INTERVAL',
+  1000,
+); // minimum ms between heap checks
 
 export const GEMINI_FLASH_MODEL = "gemini-2.5-flash";
 export const GEMINI_PRO_MODEL = "gemini-2.5-pro";

--- a/lib/lruCache.ts
+++ b/lib/lruCache.ts
@@ -1,9 +1,48 @@
+import {
+  MEMORY_PRESSURE_THRESHOLD,
+  MEMORY_PRESSURE_EVICT_RATIO,
+  MEMORY_PRESSURE_CHECK_INTERVAL,
+} from '@/constants';
+
 export class LRUCache<K, V> {
   private max: number;
   private cache = new Map<K, V>();
+  private memoryPressureThreshold: number;
+  private evictionRatio: number;
+  private checkInterval: number;
+  private isCheckingMemory = false;
+  private lastCheckTime = 0;
 
-  constructor(max: number) {
+  constructor(
+    max: number,
+    opts: {
+      memoryPressureThreshold?: number;
+      evictionRatio?: number;
+      checkInterval?: number;
+    } = {},
+  ) {
+    if (max <= 0) {
+      throw new Error(`LRUCache max size must be positive, got: ${max}`);
+    }
+    if (
+      opts.evictionRatio !== undefined &&
+      (opts.evictionRatio <= 0 || opts.evictionRatio > 1)
+    ) {
+      throw new Error(
+        `LRUCache evictionRatio must be greater than 0 and at most 1, got: ${opts.evictionRatio}`,
+      );
+    }
+    if (opts.checkInterval !== undefined && opts.checkInterval <= 0) {
+      throw new Error(
+        `LRUCache checkInterval must be positive, got: ${opts.checkInterval}`,
+      );
+    }
     this.max = max;
+    this.memoryPressureThreshold =
+      opts.memoryPressureThreshold ?? MEMORY_PRESSURE_THRESHOLD;
+    this.evictionRatio = opts.evictionRatio ?? MEMORY_PRESSURE_EVICT_RATIO;
+    this.checkInterval =
+      opts.checkInterval ?? MEMORY_PRESSURE_CHECK_INTERVAL;
   }
 
   get(key: K): V | undefined {
@@ -15,7 +54,69 @@ export class LRUCache<K, V> {
     return value;
   }
 
+  private scheduleMemoryCheck(): void {
+    const now = Date.now();
+    if (now - this.lastCheckTime < this.checkInterval) {
+      return;
+    }
+    const cb = () => void this.checkMemoryPressure();
+    const ric = globalThis.requestIdleCallback;
+    if (typeof ric === 'function') {
+      ric(cb, { timeout: 1000 });
+    } else {
+      setTimeout(cb, 100);
+    }
+  }
+
+  private async checkMemoryPressure(): Promise<void> {
+    if (this.isCheckingMemory || typeof performance === 'undefined') {
+      return;
+    }
+    this.isCheckingMemory = true;
+    this.lastCheckTime = Date.now();
+    try {
+      const perf = performance as Performance & { memory?: PerformanceMemory };
+      let memoryInfo: PerformanceMemory | undefined;
+      try {
+        memoryInfo = perf.memory;
+      } catch (e) {
+        console.warn('Error accessing performance.memory', e);
+        return;
+      }
+      let pressure = false;
+      if (memoryInfo) {
+        pressure =
+          memoryInfo.usedJSHeapSize >
+          memoryInfo.jsHeapSizeLimit * this.memoryPressureThreshold;
+      } else if (typeof navigator !== 'undefined') {
+        const nav = navigator as Navigator & { deviceMemory?: number };
+        if (
+          typeof nav.deviceMemory === 'number' &&
+          nav.deviceMemory <= 4 &&
+          this.cache.size > this.max * this.memoryPressureThreshold
+        ) {
+          pressure = true;
+        }
+      }
+      if (pressure) {
+        const minEntries = Math.max(Math.floor(this.cache.size * 0.1), 1);
+        const toRemove = Math.min(
+          Math.ceil(this.cache.size * this.evictionRatio),
+          this.cache.size - minEntries,
+        );
+        const keys = Array.from(this.cache.keys()).slice(0, toRemove);
+        keys.forEach(key => this.cache.delete(key));
+        console.warn(
+          `LRU cache evicted ${toRemove} entries due to memory pressure`,
+        );
+      }
+    } finally {
+      this.isCheckingMemory = false;
+    }
+  }
+
   set(key: K, value: V): void {
+    this.scheduleMemoryCheck();
     if (this.cache.has(key)) {
       this.cache.delete(key);
     } else if (this.cache.size >= this.max) {

--- a/lib/rateLimiter.ts
+++ b/lib/rateLimiter.ts
@@ -1,0 +1,39 @@
+export class RateLimiter {
+  private timestamps: number[] = [];
+  constructor(private maxPerInterval: number, private intervalMs: number) {
+    if (maxPerInterval <= 0) {
+      throw new Error(
+        `RateLimiter maxPerInterval must be positive, got: ${maxPerInterval}`,
+      );
+    }
+    if (intervalMs <= 0) {
+      throw new Error(
+        `RateLimiter intervalMs must be positive, got: ${intervalMs}`,
+      );
+    }
+  }
+  canProceed(): boolean {
+    const now = Date.now();
+    this.pruneExpired(now);
+    return this.timestamps.length < this.maxPerInterval;
+  }
+  getRemainingCapacity(): { remaining: number; resetMs: number } {
+    const now = Date.now();
+    this.pruneExpired(now);
+    return {
+      remaining: Math.max(0, this.maxPerInterval - this.timestamps.length),
+      resetMs:
+        this.timestamps.length > 0
+          ? this.timestamps[0] + this.intervalMs - now
+          : 0,
+    };
+  }
+  private pruneExpired(now: number): void {
+    while (this.timestamps.length > 0 && now - this.timestamps[0] >= this.intervalMs) {
+      this.timestamps.shift();
+    }
+  }
+  recordAction(): void {
+    this.timestamps.push(Date.now());
+  }
+}

--- a/lib/securityUtils.ts
+++ b/lib/securityUtils.ts
@@ -1,0 +1,20 @@
+import { equal } from '@stablelib/constant-time';
+
+export const encoder = new TextEncoder();
+
+export function timingSafeEqual(a: string, b: string): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') {
+    return false;
+  }
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  return equal(aBytes, bBytes);
+}
+
+export async function hashSessionId(id: string): Promise<string> {
+  const data = encoder.encode(id);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@byterover/cipher": "^0.3.0",
         "@dqbd/tiktoken": "^1.0.22",
         "@google/genai": "^1.15.0",
+        "@stablelib/constant-time": "^2.0.1",
         "escape-html": "^1.0.3",
         "focus-trap-react": "^11.0.4",
         "framer-motion": "^11.3.12",
@@ -3063,6 +3064,12 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@stablelib/constant-time": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-2.0.1.tgz",
+      "integrity": "sha512-0NWPogffRm+UWBH0+iM5otZmNrVe5OHFIvyoNIVankMAYOQzMwcdVALOVPrB5Ho0dST+Oc3H8/hPh65Z8R/uew==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-dom": "^18.3.1",
     "react-virtuoso": "^4.14.0",
     "wasm-feature-detect": "^1.8.0",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "@stablelib/constant-time": "^2.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/performance.d.ts
+++ b/performance.d.ts
@@ -1,0 +1,45 @@
+/**
+ * Chrome-specific memory usage information for JavaScript heaps.
+ * Non-standard API: available in Chromium-based browsers only.
+ */
+interface PerformanceMemory {
+  /** Bytes of JS heap used by the page */
+  usedJSHeapSize: number;
+  /** Maximum size of the JS heap in bytes */
+  jsHeapSizeLimit: number;
+  /** Total allocated heap size in bytes */
+  totalJSHeapSize: number;
+}
+
+/**
+ * Augments the global Performance interface with the optional `memory` field.
+ * See https://developer.chrome.com/docs/devtools/performance/reference for details.
+ */
+interface Performance {
+  memory?: PerformanceMemory;
+}
+
+interface Navigator {
+  /** Approximate device memory in gigabytes. Non-standard. */
+  deviceMemory?: number;
+}
+
+/** Callback deadline info for requestIdleCallback. */
+interface IdleDeadline {
+  readonly didTimeout: boolean;
+  timeRemaining(): DOMHighResTimeStamp;
+}
+
+/** Options for requestIdleCallback. */
+interface IdleRequestOptions {
+  timeout?: number;
+}
+
+interface Window {
+  requestIdleCallback(
+    callback: (deadline: IdleDeadline) => void,
+    opts?: IdleRequestOptions,
+  ): number;
+  cancelIdleCallback(handle: number): void;
+}
+

--- a/tests/cipherService.test.ts
+++ b/tests/cipherService.test.ts
@@ -73,8 +73,33 @@ describe('cipherService', () => {
     vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
     vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
     (globalThis as any).__TEST_IP__ = '1.1.1.1';
+    const mem = await import('@/lib/memoryLogger');
+    const log = vi.spyOn(mem, 'logMemory').mockImplementation(() => {});
     const { storeRunRecord } = await import('@/services/cipherService');
-    await expect(storeRunRecord(sampleRun, 'invalid')).rejects.toThrow('Invalid sessionId');
+    await expect(storeRunRecord(sampleRun, 'invalid<script>')).rejects.toThrow(
+      'Invalid session identifier format - expected UUID v4 like 123e4567-e89b-12d3-a456-426614174000',
+    );
+    expect(log).toHaveBeenCalledWith('cipher.store.invalidSession', {
+      sessionIdHash:
+        '1710d3a6e83be9a7bedaac4926807bcd1fe75cd9668c9249bf9822e0819518de',
+    });
+    log.mockRestore();
+  });
+
+  it('returns empty array and logs sanitized id for fetch with invalid sessionId', async () => {
+    vi.stubEnv('VITE_USE_CIPHER_MEMORY', 'true');
+    vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
+    (globalThis as any).__TEST_IP__ = '1.1.1.1';
+    const mem = await import('@/lib/memoryLogger');
+    const log = vi.spyOn(mem, 'logMemory').mockImplementation(() => {});
+    const { fetchRelevantMemories } = await import('@/services/cipherService');
+    const res = await fetchRelevantMemories('q', 'invalid<script>');
+    expect(res).toEqual([]);
+    expect(log).toHaveBeenCalledWith('cipher.fetch.invalidSession', {
+      sessionIdHash:
+        '1710d3a6e83be9a7bedaac4926807bcd1fe75cd9668c9249bf9822e0819518de',
+    });
+    log.mockRestore();
   });
 
   it('throws when CSP header missing', async () => {
@@ -313,6 +338,7 @@ describe('cipherService', () => {
     vi.stubEnv('VITE_CIPHER_SERVER_URL', 'http://cipher');
     vi.stubEnv('VITE_CIPHER_CIRCUIT_BREAKER_THRESHOLD', '2');
     vi.stubEnv('VITE_CIPHER_CIRCUIT_BREAKER_RESET_MS', '1000');
+    const rand = vi.spyOn(Math, 'random').mockReturnValue(0);
     (globalThis as any).__TEST_IP__ = '1.1.1.1';
     const fetchMock = vi
       .fn()
@@ -335,6 +361,7 @@ describe('cipherService', () => {
     expect(after).toEqual([]);
     expect(fetchMock).toHaveBeenCalledTimes(3);
     vi.useRealTimers();
+    rand.mockRestore();
   });
 
   it('no-ops when disabled', async () => {

--- a/tests/contextBuilder.test.ts
+++ b/tests/contextBuilder.test.ts
@@ -5,7 +5,7 @@ import { appendSessionContext, __clearSessionCache } from '@/lib/sessionCache';
 
 describe('buildContextualPrompt', () => {
   beforeEach(() => {
-    __clearSessionCache();
+    __clearSessionCache(true);
   });
   afterEach(() => {
     vi.restoreAllMocks();

--- a/tests/lruCache.test.ts
+++ b/tests/lruCache.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { LRUCache } from '@/lib/lruCache';
+import { MEMORY_PRESSURE_THRESHOLD } from '@/constants';
+
+describe('LRUCache', () => {
+  const originalPerformance = globalThis.performance;
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'performance', {
+      value: { memory: { usedJSHeapSize: 0, jsHeapSizeLimit: 100 } },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'performance', {
+      value: originalPerformance,
+      configurable: true,
+    });
+  });
+
+  it('throws for non-positive max size', () => {
+    expect(() => new LRUCache<string, number>(0)).toThrow(
+      'LRUCache max size must be positive, got: 0',
+    );
+    expect(() => new LRUCache<string, number>(-1)).toThrow(
+      'LRUCache max size must be positive, got: -1',
+    );
+  });
+
+  it('evicts entries under memory pressure', () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cache = new LRUCache<string, number>(2, { checkInterval: 1 });
+    cache.set('a', 1);
+    cache.set('b', 2);
+    vi.runAllTimers();
+    const mem = (globalThis.performance as any).memory;
+    mem.usedJSHeapSize = mem.jsHeapSizeLimit * MEMORY_PRESSURE_THRESHOLD + 1;
+    vi.advanceTimersByTime(1);
+    cache.set('c', 3);
+    vi.runAllTimers();
+    expect(warn).toHaveBeenCalledWith(
+      'LRU cache evicted 1 entries due to memory pressure',
+    );
+    expect(cache.size).toBe(1);
+    expect(cache.has('c')).toBe(true);
+    warn.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('supports configurable thresholds and eviction ratios', () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cache = new LRUCache<string, number>(4, {
+      memoryPressureThreshold: 0.5,
+      evictionRatio: 0.25,
+      checkInterval: 1,
+    });
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    cache.set('d', 4);
+    vi.runAllTimers();
+    const mem = (globalThis.performance as any).memory;
+    mem.usedJSHeapSize = mem.jsHeapSizeLimit * 0.6;
+    vi.advanceTimersByTime(1);
+    cache.set('e', 5);
+    vi.runAllTimers();
+    expect(warn).toHaveBeenCalledWith(
+      'LRU cache evicted 1 entries due to memory pressure',
+    );
+    expect(cache.size).toBe(3);
+    expect(cache.has('e')).toBe(true);
+    warn.mockRestore();
+    vi.useRealTimers();
+  });
+});

--- a/tests/rateLimiter.test.ts
+++ b/tests/rateLimiter.test.ts
@@ -1,0 +1,44 @@
+import { RateLimiter } from '@/lib/rateLimiter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('RateLimiter', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+  it('limits actions per interval with sliding window', () => {
+    const rl = new RateLimiter(2, 1000);
+    expect(rl.canProceed()).toBe(true);
+    rl.recordAction();
+    expect(rl.canProceed()).toBe(true);
+    rl.recordAction();
+    expect(rl.canProceed()).toBe(false);
+    vi.advanceTimersByTime(500);
+    expect(rl.canProceed()).toBe(false);
+    vi.advanceTimersByTime(500);
+    expect(rl.canProceed()).toBe(true);
+  });
+
+  it('reports remaining capacity and reset time', () => {
+    const rl = new RateLimiter(2, 1000);
+    let info = rl.getRemainingCapacity();
+    expect(info.remaining).toBe(2);
+    expect(info.resetMs).toBe(0);
+    rl.recordAction();
+    vi.advanceTimersByTime(400);
+    info = rl.getRemainingCapacity();
+    expect(info.remaining).toBe(1);
+    expect(info.resetMs).toBe(600);
+    vi.advanceTimersByTime(600);
+    info = rl.getRemainingCapacity();
+    expect(info.remaining).toBe(2);
+    expect(info.resetMs).toBe(0);
+  });
+
+  it('validates constructor inputs', () => {
+    expect(() => new RateLimiter(0, 1000)).toThrow(
+      'RateLimiter maxPerInterval must be positive, got: 0',
+    );
+    expect(() => new RateLimiter(1, 0)).toThrow(
+      'RateLimiter intervalMs must be positive, got: 0',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- expose memory-pressure tuning via environment variables
- throttle cache eviction checks and add remaining-capacity query to rate limiter
- hash session identifiers before logging
- document adaptive cache feature

## Testing
- `npm ci`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b8d9e5ecc88322a2bc67396828f653